### PR TITLE
fix: remove slash character at the end if exists

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -55,7 +55,7 @@ const Home = (): JSX.Element => {
 
   /* Check is valid address, either show err or redirect to results page */
   const submit = () => {
-    let address = userInput;
+    let address = userInput.endsWith("/") ? userInput.slice(0, -1) : userInput;
     const addressType = determineAddressType(address);
   
     if (addressType === 'empt') {


### PR DESCRIPTION
### Main changes

- Updated `Home` component to remove the `/` symbol if was included in the input field. 

### Notes

I was not able to test it locally, also I am not sure if this is the best place in the source code to sanitize the url. 

### Context
![bug-web-check](https://github.com/Lissy93/web-check/assets/5110813/03a7bd5b-450c-4089-86c7-9b21c38b9de7)



Some browsers are including `/` at the end of the urls when you copy/paste. At least for Chrome with Macos.

### Changelog

- a3d7463df6370337f65c7ea859490160ab92f29b fix: remove slash character at the end if exists by @ulisesGascon

