### PR TITLE
fix url bug

### DIFF
--- a/src/utils/address-type-checker.ts
+++ b/src/utils/address-type-checker.ts
@@ -7,13 +7,12 @@ export type AddressType = 'ipV4' | 'ipV6' | 'url' | 'err' | 'empt';
 
 /* Checks if a given string looks like a URL */
 const isUrl = (value: string):boolean => {
-  const urlPattern = new RegExp(
-    '^(https?:\\/\\/)?' + 
-    '(?!([0-9]{1,3}\\.){3}[0-9]{1,3})' + // Exclude IP addresses
-    '(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*' + // Domain name or a subdomain
-    '([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$', // Second level domain
-    'i' // Case-insensitive
-  );
+  var urlPattern = new RegExp('^(https?:\\/\\/)?'+ // validate protocol
+    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // validate domain name
+    '((\\d{1,3}\\.){3}\\d{1,3}))'+ // validate OR ip (v4) address
+    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // validate port and path
+    '(\\?[;&a-z\\d%_.~+=-]*)?'+ // validate query string
+    '(\\#[-a-z\\d_]*)?$','i'); // validate fragment locator
   return urlPattern.test(value);
 };
 


### PR DESCRIPTION
The search bar wasn't working how it was supposed to do because urls like https://www.youtube.com/watch?v=wIzwyyHolRs&t=761s generated the error "Must be a valid URL, IPv4 or IPv6 Address".
After some research i found out that the problem was in the file "adress-type-checker.ts" in particular the function isUrl contained a little error which i fixed in this commit, now i think its more delightful to use the application ^^

P.S. 
probably this will fix issue #21 too