### PR TITLE
Allow for screenshot within Docker

### DIFF
--- a/api/screenshot.js
+++ b/api/screenshot.js
@@ -21,7 +21,7 @@ const handler = async (targetUrl) => {
   let browser = null;
   try {
       browser = await puppeteer.launch({
-      args: chromium.args,
+      args: [...chromium.args, '--no-sandbox'], // Add --no-sandbox flag
       defaultViewport: { width: 800, height: 600 },
       executablePath: process.env.CHROME_PATH || await chromium.executablePath,
       headless: chromium.headless,


### PR DESCRIPTION
Chromium in Docker needs to be startet without sandbox or screenshot will fail.
I can also add checks if run inside docker so `--no-sandbox` will only be applied if running inside a container.