### PR TITLE
Adding linux/arm64 platform to docker build-push-action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64/v8
           tags: |
             ${{ env.GHCR_TAG }}
             ${{ env.DOCKERHUB_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -qq --fix-missing && \
     wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
     echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
     apt-get update -qq && \
-    apt-get -qqy --no-install-recommends install chromium traceroute && \
+    apt-get -qqy --no-install-recommends install chromium traceroute python make g++ && \
     rm -rf /var/lib/apt/lists/* 
 
 # Run the Chromium browser's version command and redirect its output to the /etc/chromium-version file
@@ -30,7 +30,7 @@ COPY package.json yarn.lock ./
 
 # Run yarn install to install dependencies and clear yarn cache
 RUN apt-get update && \
-    yarn install --production && \
+    yarn install --production --frozen-lockfile --network-timeout 100000 && \
     rm -rf /app/node_modules/.cache
 
 # Copy all files to working directory


### PR DESCRIPTION
# Summary

Adding linux/arm64 platform to docker build-push-action

Also merged in the changes from https://github.com/Lissy93/web-check/pull/55 _(**CC:** @Lissy93 )_

# Additional Resources / Context

Turns out building a `arm64` image for yarn projects on GitHub runners is less-easy than one might suspect. Specifically...

## Issue: `yarn install` timeouts
I encountered timeout issues pulling yarn dependencies, ultimately due to the emulation from QEMU. This can be worked around via extending the timeout to something long.

**Solution:** Adding `--frozen-lockfile --network-timeout 100000` in the `Dockerfile`

## Issue: missing python
I also encountered issues that python was missing from the path. A quick internet search showed that having `apt` install this would likely resolve the issue.

**Solution:** Adding `python make g++` in the `Dockerfile` (and, also merging in the changes from #55 )

## Resources
Below are some links/resources I found that helped me address these issues:
- https://github.com/bddvlpr/untis-ics-sync/issues/2
- https://github.com/fastenhealth/fasten-onprem/issues/43
- https://github.com/nodejs/docker-node/issues/1335
- https://github.com/fastenhealth/fasten-onprem/issues/34

# Details / Testing

I forked this repo to my own -> https://github.com/ChrisCarini/web-check (I may only keep this fork around for the life of this PR), changed .github/workflows/docker.yml#18 to be my `DOCKER_USER` then ran the workflow.

## Before

Before the change in this PR, the workflow succeeded, publishing an image with the single expected os/arch (`linux/amd64`):

![Screenshot 2024-02-28 at 20 36 14](https://github.com/Lissy93/web-check/assets/6374067/5c8f0919-a8c7-4b4b-9664-c67558182370)


## After

I incorporated the change in this PR, and re-ran the workflow, which succeeded. As you can see below, the image was published with the two expected os/arch (`linux/amd64` and `linux/arm64`):

![Screenshot 2024-02-29 at 08 38 05](https://github.com/Lissy93/web-check/assets/6374067/b6759ed0-7e7d-428f-ba78-9f804cd47981)


# Bug(s)

Fixes #73