### PR TITLE
Improve Quality Summary

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 # Everything is optional, but some features won't work without external API access
 
 # API Keys for external services (backend)
-GOOGLE_CLOUD_API_KEY=''
+GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY=''
 TORRENT_IP_API_KEY=''
 SECURITY_TRAILS_API_KEY=''
 BUILT_WITH_API_KEY=''

--- a/.github/README.md
+++ b/.github/README.md
@@ -799,14 +799,14 @@ But there are some optional environmental variables that you can set to give you
 
 Key | Value
 ---|---
-`GOOGLE_CLOUD_API_KEY` | A Google API key ([get here](https://cloud.google.com/api-gateway/docs/authenticate-api-keys)). This can be used to return quality metrics for a site
+`GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY` | A Google Page Speed Insights API key ([get here](https://developers.google.com/speed/docs/insights/v5/get-started)). This is used for running Lighthouse scans
 `REACT_APP_SHODAN_API_KEY` | A Shodan API key ([get here](https://account.shodan.io/)). This will show associated host names for a given domain
 `REACT_APP_WHO_API_KEY` | A WhoAPI key ([get here](https://whoapi.com/)). This will show more comprehensive WhoIs records than the default job
 
 <details>
   <summary><small>Full / Upcoming Vals</small></summary>
   
-- `GOOGLE_CLOUD_API_KEY` - A Google API key ([get here](https://cloud.google.com/api-gateway/docs/authenticate-api-keys)). This can be used to return quality metrics for a site
+- `GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY` - A Google Page Speed Insights API key ([get here](https://developers.google.com/speed/docs/insights/v5/get-started)). This is used for running Lighthouse scans
 - `REACT_APP_SHODAN_API_KEY` - A Shodan API key ([get here](https://account.shodan.io/)). This will show associated host names for a given domain
 - `REACT_APP_WHO_API_KEY` - A WhoAPI key ([get here](https://whoapi.com/)). This will show more comprehensive WhoIs records than the default job
 - `SECURITY_TRAILS_API_KEY` - A Security Trails API key ([get here](https://securitytrails.com/corp/api)). This will show org info associated with the IP

--- a/api/quality.js
+++ b/api/quality.js
@@ -2,10 +2,10 @@ const axios = require('axios');
 const middleware = require('./_common/middleware');
 
 const handler = async (url, event, context) => {
-  const apiKey = process.env.GOOGLE_CLOUD_API_KEY;
+  const apiKey = process.env.GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY;
 
   if (!apiKey) {
-    throw new Error('API key (GOOGLE_CLOUD_API_KEY) not set');
+    throw new Error('API key (GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY) not set');
   }
 
   const endpoint = `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=${encodeURIComponent(url)}&category=PERFORMANCE&category=ACCESSIBILITY&category=BEST_PRACTICES&category=SEO&category=PWA&strategy=mobile&key=${apiKey}`;

--- a/api/threats.js
+++ b/api/threats.js
@@ -4,9 +4,9 @@ const middleware = require('./_common/middleware');
 
 const getGoogleSafeBrowsingResult = async (url) => {
   try {
-    const apiKey = process.env.GOOGLE_CLOUD_API_KEY;
+    const apiKey = process.env.GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY;
     if (!apiKey) {
-      return { error: 'GOOGLE_CLOUD_API_KEY is required for the Google Safe Browsing check' };
+      return { error: 'GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY is required for the Google Safe Browsing check' };
     }
     const apiEndpoint = `https://safebrowsing.googleapis.com/v4/threatMatches:find?key=${apiKey}`;
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,10 +13,10 @@
   # NODE_VERSION = "16.16.0"  # Set the version of Node.js to use
 
   # Optional secrets and API keys (uncomment if you want to add these)
-  # GOOGLE_CLOUD_API_KEY=''     # Google Cloud API key, for running Lighthouse scans
-  # BUILT_WITH_API_KEY=''       # BuiltWith API key, for detecting site features
-  # REACT_APP_SHODAN_API_KEY='' # Shodan API key, for using Shodan scan API
-  # REACT_APP_WHO_API_KEY=''    # WhoAPI key, for iniiating client-side whois lookup
+  # GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY=''     # Google Cloud API key, for running Lighthouse scans
+  # BUILT_WITH_API_KEY=''                     # BuiltWith API key, for detecting site features
+  # REACT_APP_SHODAN_API_KEY=''               # Shodan API key, for using Shodan scan API
+  # REACT_APP_WHO_API_KEY=''                  # WhoAPI key, for iniiating client-side whois lookup
 
 # Redirect the /api/* path to the lambda functions
 [[redirects]]

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,7 +5,7 @@ provider:
   runtime: nodejs14.x
   region: us-east-1
   # environment:
-  #   GOOGLE_CLOUD_API_KEY: ${ssm:GOOGLE_CLOUD_API_KEY~true, ''}
+  #   GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY: ${ssm:GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY~true, ''}
   #   TORRENT_IP_API_KEY: ${ssm:TORRENT_IP_API_KEY~true, ''}
   #   SECURITY_TRAILS_API_KEY: ${ssm:SECURITY_TRAILS_API_KEY~true, ''}
   #   BUILT_WITH_API_KEY: ${ssm:BUILT_WITH_API_KEY~true, ''}
@@ -21,7 +21,7 @@ provider:
       Action:
         - ssm:GetParameter
       Resource:
-        - arn:aws:ssm:us-east-1:${env:AWS_ACCOUNT_ID}:parameter/GOOGLE_CLOUD_API_KEY
+        - arn:aws:ssm:us-east-1:${env:AWS_ACCOUNT_ID}:parameter/GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY
         - arn:aws:ssm:us-east-1:${env:AWS_ACCOUNT_ID}:parameter/TORRENT_IP_API_KEY
         - arn:aws:ssm:us-east-1:${env:AWS_ACCOUNT_ID}:parameter/SECURITY_TRAILS_API_KEY
         - arn:aws:ssm:us-east-1:${env:AWS_ACCOUNT_ID}:parameter/BUILT_WITH_API_KEY

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -225,9 +225,9 @@ const About = (): JSX.Element => {
 
         <ul>
           <li>
-            <code>GOOGLE_CLOUD_API_KEY</code>
-            : <a href="https://cloud.google.com/api-gateway/docs/authenticate-api-keys">A Google API key</a>
-            <i> Used to return quality metrics for a site</i>
+            <code>GOOGLE_PAGE_SPEED_INSIGHTS_API_KEY</code>
+            : <a href="https://developers.google.com/speed/docs/insights/v5/get-started">A Google Page Speed Insights API key</a>
+            <i> This is used for running Lighthouse scans</i>
           </li>
           <li>
             <code>REACT_APP_SHODAN_API_KEY</code>


### PR DESCRIPTION
This PR attempts to resolve #10; however, I only just started using Web-Check and this may not be the preferred approach. That said, I’m happy to incorporate any feedback to make this PR more useful. :)

One unresolved issue is related to `api/threats.js` which appears to indicate that `GOOGLE_CLOUD_API_KEY` may be intended to work for both Page Speed Insights (Lighthouse) and Google Safe Browsing. Any clarification here would be greatly appreciated.

The gist of this update is to rename the API key environment variable and to provide a more direct URL to assist users with adding support for the Quality Summary section of the report.

Additionally, this may introduce a breaking change for current users as they would need to modify their environment variables. I’m not sure how to best handle this type of situation.