### PR TITLE
add compose dev and upgrade node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,27 @@
 # Build stage
-FROM node:16-buster-slim AS build
+FROM node:20-buster-slim AS base
 
 WORKDIR /app
 
 COPY package.json yarn.lock ./
 
-RUN apt-get update && \
-    yarn install --production && \
-    rm -rf /app/node_modules/.cache
+RUN apt update -y && \
+    apt upgrade -y 
 
+FROM base as dev
+
+RUN yarn && \
+    rm -rf /app/node_modules/.cache
+ENTRYPOINT ["yarn"]
+
+FROM base AS build
 COPY . .
 
-RUN yarn build --production
+RUN yarn build --production && \
+    rm -rf /app/node_modules/.cache
 
 # Final stage
-FROM node:16-buster-slim AS final
+FROM node:20-buster-slim AS final
 
 WORKDIR /app
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,11 @@
+version: '3.9'
+services:
+  web-check:
+    container_name: Web-Check
+    command: dev
+    build:
+      target: dev
+    volumes:
+      - ./:/app
+    ports:
+      - 8080:8888


### PR DESCRIPTION
Hello great project, I was testing it thru github codespaces and wanted to test a docker development setup, so just get in codespaces and type: `docker compose -f docker-compose.dev.yaml up --build web-check` to test the changes, it also make docker local development easier for devs since it uses a volume to map the container and local folder to look for file changes.
This pr changes:
- upgrade docker node image to 20-buster-slim
- add a new docker image `dev` and `base` before `build` step  
- add a docker-compose.dev.yaml file with a volume mapped to local folder