### PR TITLE
Fix bug with JSON Doctype

### DIFF
--- a/api/dnssec.js
+++ b/api/dnssec.js
@@ -25,7 +25,11 @@ const handler = async (domain) => {
           });
 
           res.on('end', () => {
-            resolve(JSON.parse(data));
+            try {
+              resolve(JSON.parse(data));
+            } catch (error) {
+              reject(new Error('Invalid JSON response'));
+            }
           });
 
           res.on('error', error => {
@@ -51,4 +55,3 @@ const handler = async (domain) => {
 
 module.exports = middleware(handler);
 module.exports.handler = middleware(handler);
-


### PR DESCRIPTION
Setting up the OSINT tool and running it locally via production ready build causes JSON Doctype Error after trying to scan some host in AWS.

Fixes #120