### PR TITLE
feat: add external mozilla observatory tool

### DIFF
--- a/src/components/misc/AdditionalResources.tsx
+++ b/src/components/misc/AdditionalResources.tsx
@@ -204,6 +204,13 @@ const resources = [
     description: 'View traffic source locations for a domain through Cloudflare',
     searchLink: 'https://radar.cloudflare.com/domains/domain/{URL}',
   },
+  {
+    title: 'Mozilla Observatory',
+    link: 'https://observatory.mozilla.org/',
+    icon: 'https://i.ibb.co/hBWh9cj/logo-mozm-5e95c457fdd1.png',
+    description: 'Assesses website security posture by analyzing various security headers and practices',
+    searchLink: 'https://observatory.mozilla.org/analyze/{URL}',
+  },
 ];
 
 const makeLink = (resource: any, scanUrl: string | undefined): string => {


### PR DESCRIPTION
Hi,
i'm adding Mozilla Observatory tool to the external tool as it very useful.

![image](https://github.com/Lissy93/web-check/assets/79602273/7d4d5584-5dce-4de3-b237-cde3a502568e)

