### PR TITLE
Add darkreader lock meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,9 @@
     <meta property="og:image" content="/banner.png">
     <meta property="og:url" content="https://web-check.xyz">
     <meta name="twitter:card" content="summary_large_image">
+
+    <!-- DarkReader -->
+    <meta name="darkreader-lock">
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
As the website is dark, we can add the `darkreader-lock` meta tag so that dark reader recognizes it being dark (see docs https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-statically)

Note, haven't tested this locally, but I'm very sure this should work :D