### PR TITLE
CICD: bumped GHA versions

### DIFF
--- a/.github/workflows/credits.yml
+++ b/.github/workflows/credits.yml
@@ -12,9 +12,9 @@ jobs:
     name: Inserts Sponsors 💓
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Updates readme with sponsors
-        uses: JamesIves/github-sponsors-readme-action@1.0.5
+        uses: JamesIves/github-sponsors-readme-action@v1
         with:
           token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
           file: .github/README.md
@@ -25,7 +25,7 @@ jobs:
     name: Inserts Contributors 💓
     steps:
       - name: Updates readme with contributors
-        uses: akhilmhdh/contributors-readme-action@v2.3.4
+        uses: akhilmhdh/contributors-readme-action@v2.3.10
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 16
 
     - name: Cache node_modules
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -35,7 +35,7 @@ jobs:
           ${{ runner.os }}-yarn-
 
     - name: Create GitHub deployment for API
-      uses: chrnorm/deployment-action@releases/v1
+      uses: chrnorm/deployment-action@releases/v2
       id: deployment_api
       with:
         token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
       
     - name: Update GitHub deployment status (API)
       if: always()
-      uses: chrnorm/deployment-status@releases/v1
+      uses: chrnorm/deployment-status@v2
       with:
         token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
         state: "${{ job.status }}"
@@ -68,15 +68,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 16
     
     - name: Cache node_modules
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -84,7 +84,7 @@ jobs:
           ${{ runner.os }}-yarn-
 
     - name: Create GitHub deployment for Frontend
-      uses: chrnorm/deployment-action@releases/v1
+      uses: chrnorm/deployment-action@v2
       id: deployment_frontend
       with:
         token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
         yarn build
     
     - name: Setup AWS
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -109,7 +109,7 @@ jobs:
       run: aws s3 sync ./build/ s3://$AWS_S3_BUCKET/ --delete
 
     - name: Invalidate CloudFront cache
-      uses: chetan/invalidate-cloudfront-action@v2.4
+      uses: chetan/invalidate-cloudfront-action@v2
       env:
         DISTRIBUTION: E30XKAM2TG9FD8
         PATHS: '/*'
@@ -119,7 +119,7 @@ jobs:
         
     - name: Update GitHub deployment status (Frontend)
       if: always()
-      uses: chrnorm/deployment-status@releases/v1
+      uses: chrnorm/deployment-status@v2
       with:
         token: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
         state: "${{ job.status }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Extract tag name
         shell: bash
@@ -42,27 +42,27 @@ jobs:
           fi
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
         
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKERHUB_REGISTRY }}
           username: ${{ env.DOCKER_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -8,7 +8,7 @@ jobs:
   codeberg:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: pixta-dev/repository-mirroring-action@v1
         with:


### PR DESCRIPTION
Updated GitHub Actions versions (current versions use outdated Node runtime and other deprecated features)