### PR TITLE
fix: Fix 404 errors for github repository and license urls in the footer

### DIFF
--- a/src/components/scafold/Footer.astro
+++ b/src/components/scafold/Footer.astro
@@ -1,6 +1,6 @@
 ---
 const repo = 'github.com/lissy93/web-check';
-const github = `https://github.com/${repo}`;
+const github = `https://${repo}`;
 
 const licenseText = 'MIT';
 const licenseLink = `${github}/blob/master/LICENSE`;


### PR DESCRIPTION
This PR fixes the 404 errors from the homepage footer links.