### PR TITLE
Removing a line that causes false negatives on /.well-known/security.txt

### DIFF
--- a/api/security-txt.js
+++ b/api/security-txt.js
@@ -53,7 +53,6 @@ const securityTxtHandler = async (urlParam) => {
   for (let path of SECURITY_TXT_PATHS) {
     try {
       const result = await fetchSecurityTxt(url, path);
-      if (result && result.includes('<html')) return { isPresent: false };
       if (result) {
         return {
           isPresent: true,


### PR DESCRIPTION
Removed a line that was causing to instantly return false on the first iteration for `/security.txt` even though it might exist on `/.well-known/security.txt`. Loop still falls down on a return false at the end if both `/security.txt` and `/.well-known/security.txt` does not exists.