### PR TITLE
fix: Change Sucuri SiteCheck link

### DIFF
--- a/src/web-check-live/components/misc/AdditionalResources.tsx
+++ b/src/web-check-live/components/misc/AdditionalResources.tsx
@@ -134,7 +134,7 @@ const resources = [
     link: 'https://sitecheck.sucuri.net/',
     icon: 'https://i.ibb.co/K5pTP1K/Sucuri-site-check.png',
     description: 'Checks a URL against blacklists and known threats',
-    searchLink: 'https://www.ssllabs.com/ssltest/analyze.html?d={URL}',
+    searchLink: 'https://sitecheck.sucuri.net/results/{URL}',
   },
   {
     title: 'Domain Tools',


### PR DESCRIPTION
Fixes the Securi SiteCheck link under External Tools to point to the correct URL, instead of the SSL Labs test link. 😄 

Closes #92 