### PR TITLE
adds ports to check environment variable.

### DIFF
--- a/api/ports.js
+++ b/api/ports.js
@@ -2,12 +2,17 @@ import net from 'net';
 import middleware from './_common/middleware.js';
 
 // A list of commonly used ports.
-const PORTS = [
+const DEFAULT_PORTS_TO_CHECK = [
   20, 21, 22, 23, 25, 53, 80, 67, 68, 69,
   110, 119, 123, 143, 156, 161, 162, 179, 194,
   389, 443, 587, 993, 995,
   3000, 3306, 3389, 5060, 5900, 8000, 8080, 8888
 ];
+/*
+ * Checks if the env PORTS_TO_CHECK is set, if so the string is split via "," to get an array of ports to check.
+ * If the env is not set, return the default commonly used ports.
+ */
+const PORTS = process.env.PORTS_TO_CHECK ? process.env.PORTS_TO_CHECK.split(",") : DEFAULT_PORTS_TO_CHECK
 
 async function checkPort(port, domain) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Checks if the env PORTS_TO_CHECK is set, if so the string is split via "," to get an array of ports to check. If the env is not set, return the default commonly used ports.