### PR TITLE
fix: openapi-spec.yml whois endpoint has wrong query parameter name (domain instead of url)

### DIFF
--- a/public/resources/openapi-spec.yml
+++ b/public/resources/openapi-spec.yml
@@ -2537,7 +2537,7 @@ paths:
       tags:
         - Server Info
       parameters:
-        - name: domain
+        - name: url
           in: query
           required: true
           description: The domain to retrieve WHOIS information for


### PR DESCRIPTION
Wrong query parameter name mentioned in openapi-spec.yml
whois api takes url query parameter not domain
<img width="1468" height="580" alt="image" src="https://github.com/user-attachments/assets/597853f2-2b59-4db3-bb9c-73f2158a1219" />
<img width="1919" height="594" alt="image" src="https://github.com/user-attachments/assets/58593065-0ee4-4007-a7a0-0bb65ed0891b" />
<img width="793" height="210" alt="image" src="https://github.com/user-attachments/assets/47151e70-ba79-4e9f-83a4-6eac026cec24" />
