### PR TITLE
Fixes incorrect references to Tranco list size (100M to 1M).

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -654,7 +654,7 @@ This is useful for understanding the history of a site, and how it has changed o
 <img width="300" src="https://i.ibb.co/nkbczgb/Screenshot-from-2023-08-14-22-02-40.png" align="right" />
 
 ###### Description
-This check shows the global rank of the requested site. This is only accurate for websites which are in the top 100 million list. We're using data from the Tranco project (see below), which collates the top sites on the web from Umbrella, Majestic, Quantcast, the Chrome User Experience Report and Cloudflare Radar.
+This check shows the global rank of the requested site. This is only accurate for websites which are in the top 1 million list. We're using data from the Tranco project (see below), which collates the top sites on the web from Umbrella, Majestic, Quantcast, the Chrome User Experience Report and Cloudflare Radar.
 
 ###### Use Cases
 Knowing a websites overall global rank can be useful for understanding the scale of the site, and for comparing it to other sites. It can also be useful for understanding the relative popularity of a site, and for identifying potential trends.

--- a/api/rank.js
+++ b/api/rank.js
@@ -13,7 +13,7 @@ const rankHandler = async (url) => {
       `https://tranco-list.eu/api/ranks/domain/${domain}`, { timeout: 5000 }, auth,
       );
     if (!response.data || !response.data.ranks || response.data.ranks.length === 0) {
-      return { skipped: `Skipping, as ${domain} isn't ranked in the top 100 million sites yet.`};
+      return { skipped: `Skipping, as ${domain} isn't ranked in the top 1 million sites yet.`};
     }
     return response.data;
   } catch (error) {

--- a/src/web-check-live/utils/docs.ts
+++ b/src/web-check-live/utils/docs.ts
@@ -446,7 +446,7 @@ const docs: Doc[] = [
   {
     id: 'rank',
     title: 'Global Ranking',
-    description: 'This check shows the global rank of the requested site. This is only accurate for websites which are in the top 100 million list. We\'re using data from the Tranco project (see below), which collates the top sites on the web from Umbrella, Majestic, Quantcast, the Chrome User Experience Report and Cloudflare Radar.',
+    description: 'This check shows the global rank of the requested site. This is only accurate for websites which are in the top 1 million list. We\'re using data from the Tranco project (see below), which collates the top sites on the web from Umbrella, Majestic, Quantcast, the Chrome User Experience Report and Cloudflare Radar.',
     use: 'Knowing a websites overall global rank can be useful for understanding the scale of the site, and for comparing it to other sites. It can also be useful for understanding the relative popularity of a site, and for identifying potential trends.',
     resources: [
       { title: 'Tranco List', link: 'https://tranco-list.eu/' },


### PR DESCRIPTION
Updates documentation and API responses to reflect the correct number.

Why this is needed:
Tranco provides only the top 1 million websites, not 100 million.
This correction prevents misinformation and ensures accuracy across the project.

