### PR TITLE
Fix: Use dns.promises in mail-config to prevent callback error

### DIFF
--- a/api/mail-config.js
+++ b/api/mail-config.js
@@ -1,4 +1,4 @@
-import dns from 'dns';
+import { promises as dns } from 'dns';
 import URL from 'url-parse';
 import middleware from './_common/middleware.js';
 


### PR DESCRIPTION
The `mail-config` job crashes because it uses `await dns.resolveMx` which requires the Promise API, but the default import provides the Callback API.

Error observed: `The "callback" argument must be of type function. Received undefined`

This PR switches the import to `{ promises as dns }` to support the async/await usage present in the code.