### PR TITLE
Improve TLS handler with polling mechanism and configurable API URL

### DIFF
--- a/api/tls.js
+++ b/api/tls.js
@@ -1,27 +1,63 @@
 import axios from 'axios';
 import middleware from './_common/middleware.js';
 
-const MOZILLA_TLS_OBSERVATORY_API = 'https://tls-observatory.services.mozilla.com/api/v1';
+const MOZILLA_TLS_OBSERVATORY_API =
+  process.env. TLS_OBSERVATORY_API ||
+  'https://tls-observatory.services. mozilla.com/api/v1';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const tlsHandler = async (url) => {
   try {
     const domain = new URL(url).hostname;
-    const scanResponse = await axios.post(`${MOZILLA_TLS_OBSERVATORY_API}/scan?target=${domain}`);
-    const scanId = scanResponse.data.scan_id;
 
-    if (typeof scanId !== 'number') {
-      return {
-        statusCode: 500,
-        body: { error: 'Failed to get scan_id from TLS Observatory' },
-      };
+    const scanResponse = await axios.post(
+      `${MOZILLA_TLS_OBSERVATORY_API}/scan? target=${domain}&rescan=true`
+    );
+
+    const scanId = scanResponse.data.scan_id;
+    if (scanId === undefined || scanId === null) {
+      return { statusCode: 500, body: { error: 'Failed to get scan_id' } };
     }
-    const resultResponse = await axios.get(`${MOZILLA_TLS_OBSERVATORY_API}/results?id=${scanId}`);
+
+    const MAX_RETRIES = 20;
+    const POLLING_INTERVAL = 2000;
+
+    let attempts = 0;
+    let resultResponse;
+
+    while (attempts < MAX_RETRIES) {
+      attempts++;
+
+      resultResponse = await axios. get(
+        `${MOZILLA_TLS_OBSERVATORY_API}/results?id=${scanId}`
+      );
+
+      const data = resultResponse. data;
+
+      const completed =
+        data.completion_perc === 100 ||
+        data.state === 'FINISHED' ||
+        data.state === 'READY' ||
+        data.analysis?. state === 'COMPLETED';
+
+      if (completed) {
+        return { statusCode: 200, body: data };
+      }
+
+      await sleep(POLLING_INTERVAL);
+    }
+
     return {
-      statusCode: 200,
-      body: resultResponse.data,
+      statusCode: 408,
+      body: {
+        error: 'TLS scan timed out awaiting results',
+        partial_data: resultResponse?.data,
+      },
     };
   } catch (error) {
-    return { error: error.message };
+    console.error('TLS Observatory Error:', error.response?.data || error.message);
+    return { statusCode: 500, body: { error: error.message } };
   }
 };
 


### PR DESCRIPTION
## Summary
Improves the TLS handler with a polling mechanism for reliable scan results. 

## Changes
- Added configurable API URL via `TLS_OBSERVATORY_API` environment variable
- Implemented polling with retries (max 20 attempts, 2s interval) to wait for scan completion
- Added `rescan=true` parameter for fresh scans
- Added 408 timeout status with partial data when scan takes too long
- Improved error logging with response data

## Why
The previous implementation immediately fetched results after triggering a scan, which could return incomplete data if the scan hadn't finished. 