### PR TITLE
fix: show OCSP stapling as informational, not pass/fail

### DIFF
--- a/src/client/components/Results/TlsConnection.tsx
+++ b/src/client/components/Results/TlsConnection.tsx
@@ -3,6 +3,8 @@ import Row from 'client/components/Form/Row';
 
 const yesNo = (v: boolean) => (v ? '✅ Yes' : '❌ No');
 
+const ocspStatus = (v: boolean) => (v ? 'Yes' : 'Not enabled');
+
 const formatEphemeralKey = (k: any): string => {
   if (!k?.type) return '';
   const parts = [k.type];
@@ -28,7 +30,7 @@ const TlsConnectionCard = (props: {
       {d.alpnProtocol && <Row lbl="ALPN" val={d.alpnProtocol} />}
       <Row lbl="Forward Secrecy" val={yesNo(!!d.forwardSecrecy)} />
       <Row lbl="Session Resumption" val={yesNo(!!d.sessionResumption)} />
-      <Row lbl="OCSP Stapling" val={yesNo(!!d.ocspStapled)} />
+      <Row lbl="OCSP Stapling" val={ocspStatus(!!d.ocspStapled)} />
       <Row
         lbl="Certificate Trust"
         val={d.authorized ? '✅ Trusted' : `❌ ${d.authError || 'Untrusted'}`}


### PR DESCRIPTION
The TLS Connection card showed ❌ No when OCSP stapling wasn't enabled, which makes it look like a security failure. OCSP stapling is a performance optimization — absence isn't an issue.

Changed the card display from:

Before: ❌ No       ✅ Yes
After:  Not enabled  Yes

No emoji, no red cross. Just factual.

The analysis rule already uses severity: 'info' for this check, so the advisory panel was correct — only the card display was misleading.

Verified with tsc and prettier, both clean.