### PR TITLE
Prevent IPv6 DNS records from being visually truncated

### DIFF
--- a/src/client/components/Results/DnsRecords.tsx
+++ b/src/client/components/Results/DnsRecords.tsx
@@ -7,6 +7,7 @@ const styles = `
     max-height: 50rem;
     overflow-x: hidden;
     overflow-y: auto;
+    overflow-wrap: anywhere;
   }
 `;
 


### PR DESCRIPTION
## Summary
- allow long DNS record values to wrap inside the DNS Records card
- fixes full IPv6 AAAA values being visually cut off while keeping existing card scrolling behavior
- no data-fetching behavior changed

Closes #300.

## Verification
- `YARN_CACHE_FOLDER=/tmp/web-check-yarn-cache-$$ yarn install --frozen-lockfile --ignore-scripts`
- `yarn eslint --config .config/eslint.config.js src/client/components/Results/DnsRecords.tsx`
- `yarn prettier --check src/client/components/Results/DnsRecords.tsx`
- `git diff --check`

Note: the first install attempt hit a corrupt local Yarn cache; rerunning with an isolated cache completed successfully.

## Paid-fix note
If this closes the IPv6 visibility bug and saves maintainer time, I am asking $10 here: https://nicdunz.gumroad.com/l/slop-kill-pass?wanted=true

No issue if this project only handles volunteer contributions; the patch stands either way.