### PR TITLE
chore: add OCI standard labels to Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,6 +51,14 @@ jobs:
       - name: Set up Docker Buildx 🐳
         uses: docker/setup-buildx-action@v4
 
+      - name: Extract Docker metadata 🏷️
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_NAME }}
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKER_USER }}/${{ env.IMAGE_NAME }}
+
       - name: Login to GitHub Container Registry 🔑
         uses: docker/login-action@v4
         with:
@@ -72,6 +80,7 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64/v8
+          labels: ${{ steps.meta.outputs.labels }}
           tags: |
             ${{ env.GHCR_TAG }}
             ${{ env.DOCKERHUB_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM node:${NODE_VERSION}-${DEBIAN_VERSION} AS build
 # Set the container's default shell to Bash and enable some options
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
-# Install Chromium browser and Download and verify Google Chrome’s signing key
+# Install Chromium browser and Download and verify Google Chrome's signing key
 RUN apt-get update -qq --fix-missing && \
     apt-get -qqy install --allow-unauthenticated gnupg wget && \
     wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
@@ -59,6 +59,13 @@ EXPOSE ${PORT:-3000}
 ENV CHROME_PATH='/usr/bin/chromium' \
     PUPPETEER_EXECUTABLE_PATH='/usr/bin/chromium' \
     PUPPETEER_SKIP_DOWNLOAD='true'
+
+LABEL org.opencontainers.image.title="Web-Check" \
+      org.opencontainers.image.description="All-in-one OSINT tool for analysing any website" \
+      org.opencontainers.image.url="https://web-check.xyz" \
+      org.opencontainers.image.source="https://github.com/lissy93/web-check" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="Alicia Sykes"
 
 # Define the command executed when the container starts and start the server.js of the Node.js application
 CMD ["yarn", "start"]


### PR DESCRIPTION
## Context

The Docker images published by this project (`ghcr.io/lissy93/web-check`, `docker.io/lissy93/web-check`) are missing standard [OCI Image Spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md) labels. Adding these improves:

- **Dependency bot changelogs**: Renovate and Dependabot use `org.opencontainers.image.source` to locate and display changelogs/release notes in update PRs
- **Registry UI**: GHCR and Docker Hub display OCI labels (description, license, source link) in their web interface
- **Security scanning**: Tools like Trivy and Grype use `source` and `revision` for image provenance
- **Image traceability**: `version`, `revision`, and `created` enable precise build auditing

## Type

Improvement — metadata only, no functional changes.

## Labels Added

| Label | Value | Source |
|-------|-------|--------|
| `org.opencontainers.image.title` | `Web-Check` | Static (Dockerfile) + auto-generated (CI) |
| `org.opencontainers.image.description` | `All-in-one OSINT tool for analysing any website` | Static (Dockerfile) + auto-generated (CI) |
| `org.opencontainers.image.url` | `https://web-check.xyz` | Static (Dockerfile) + auto-generated (CI) |
| `org.opencontainers.image.source` | `https://github.com/lissy93/web-check` | Static (Dockerfile) + auto-generated (CI) |
| `org.opencontainers.image.licenses` | `MIT` | Static (Dockerfile) |
| `org.opencontainers.image.vendor` | `Alicia Sykes` | Static (Dockerfile) |
| `org.opencontainers.image.version` | git tag / ref | Dynamic (CI via `docker/metadata-action`) |
| `org.opencontainers.image.revision` | git SHA | Dynamic (CI via `docker/metadata-action`) |
| `org.opencontainers.image.created` | build timestamp | Dynamic (CI via `docker/metadata-action`) |

## Changes

**`Dockerfile`** — static labels added to the `final` stage (after `ENV`, before `CMD`), covering manual `docker build` invocations without CI:

```dockerfile
LABEL org.opencontainers.image.title="Web-Check" \
      org.opencontainers.image.description="All-in-one OSINT tool for analysing any website" \
      org.opencontainers.image.url="https://web-check.xyz" \
      org.opencontainers.image.source="https://github.com/lissy93/web-check" \
      org.opencontainers.image.licenses="MIT" \
      org.opencontainers.image.vendor="Alicia Sykes"
```

**`.github/workflows/docker.yml`** — adds `docker/metadata-action@v5` to generate the dynamic labels (`version`, `revision`, `created`) from GitHub context, and wires them into the existing `docker/build-push-action@v7` step via `labels: ${{ steps.meta.outputs.labels }}`. The existing tag logic is unchanged.

## Verification

After merge, labels can be verified with:
```bash
docker inspect ghcr.io/lissy93/web-check:latest | jq '.[0].Config.Labels'
```

## References

- [OCI Image Spec - Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [Renovate Docker datasource](https://docs.renovatebot.com/modules/datasource/docker/)
- [docker/metadata-action](https://github.com/docker/metadata-action)
