### PR TITLE
fix(api): block SSRF to private/reserved targets in shared middleware

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,3 +28,8 @@ WHO_API_KEY=''
 # BOSS_SERVER='false'             # Marketing homepage (only used by official instance)
 # TRUST_PROXY='1'                 # Set if running behind a reverse proxy (Traefik, nginx, etc).
                                   # Use a number of hops (e.g. '1'), 'true', or a CIDR list.
+# ALLOW_PRIVATE_TARGETS='false'   # Set to 'true' to allow checks against private / loopback /
+                                  # link-local addresses (RFC1918, 127.0.0.0/8, 169.254.0.0/16,
+                                  # fc00::/7 etc.). Off by default to prevent SSRF on public
+                                  # deployments. Only enable when self-hosting and scanning
+                                  # your own LAN intentionally.

--- a/api/_common/middleware.js
+++ b/api/_common/middleware.js
@@ -1,4 +1,5 @@
 import { bracketIPv6 } from './parse-target.js';
+import { assertSafeTarget, UnsafeTargetError } from './safe-target.js';
 
 const normalizeUrl = (url) => {
   const withScheme = url.startsWith('http') ? url : `https://${url}`;
@@ -74,6 +75,15 @@ const commonMiddleware = (handler) => {
     const url = normalizeUrl(rawUrl);
 
     try {
+      await assertSafeTarget(url);
+    } catch (error) {
+      if (error instanceof UnsafeTargetError) {
+        return response.status(400).json({ error: error.message });
+      }
+      throw error;
+    }
+
+    try {
       const result = await Promise.race([handler(url, request), createTimeoutPromise(TIMEOUT)]);
       response.status(200).json(typeof result === 'object' ? result : JSON.parse(result));
     } catch (error) {
@@ -96,6 +106,16 @@ const commonMiddleware = (handler) => {
     }
 
     const url = normalizeUrl(rawUrl);
+
+    try {
+      await assertSafeTarget(url);
+    } catch (error) {
+      if (error instanceof UnsafeTargetError) {
+        return { statusCode: 400, body: JSON.stringify({ error: error.message }), headers };
+      }
+      throw error;
+    }
+
     try {
       const result = await Promise.race([
         handler(url, event, context),

--- a/api/_common/safe-target.js
+++ b/api/_common/safe-target.js
@@ -1,0 +1,131 @@
+// Centralised SSRF guard for the API middleware.
+//
+// Every API endpoint is invoked through `commonMiddleware` with a user-supplied
+// `?url=` query parameter that ends up being passed to http clients, DNS
+// resolvers, raw TCP sockets and headless Chromium. Without validation an
+// attacker can pivot the public instance into the operator's internal network
+// (e.g. cloud metadata services on 169.254.169.254, LAN ranges, loopback).
+//
+// `assertSafeTarget` enforces:
+//   * the URL parses
+//   * the scheme is http(s) — file:, gopher:, ftp: etc. are rejected
+//   * the resolved IP (or IP literal) is not in a private / reserved / loopback
+//     / link-local / multicast / CGNAT range, for either v4 or v6
+//
+// Self-hosters who legitimately want to scan their own LAN can opt out via
+// `ALLOW_PRIVATE_TARGETS=true` in their .env.
+
+import { BlockList, isIP } from 'net';
+import { promises as dns } from 'dns';
+
+const ALLOW_PRIVATE = /^(1|true|yes)$/i.test(process.env.ALLOW_PRIVATE_TARGETS || '');
+
+// Build a BlockList covering the address space we never want web-check to
+// reach from a public deployment. Mirrors the IANA special-purpose registries.
+//
+// Note: Node's BlockList transparently handles IPv4-mapped IPv6 addresses
+// (e.g. `::ffff:127.0.0.1` matches the `127.0.0.0/8` v4 rule), so we don't
+// add an explicit `::ffff:0:0/96` subnet — doing so would block every v4
+// address by accident.
+const buildBlockList = () => {
+  const bl = new BlockList();
+  // IPv4
+  bl.addSubnet('0.0.0.0', 8); // "this network" / unspecified
+  bl.addSubnet('10.0.0.0', 8); // RFC1918
+  bl.addSubnet('100.64.0.0', 10); // CGNAT
+  bl.addSubnet('127.0.0.0', 8); // loopback
+  bl.addSubnet('169.254.0.0', 16); // link-local / cloud metadata
+  bl.addSubnet('172.16.0.0', 12); // RFC1918
+  bl.addSubnet('192.0.0.0', 24); // IETF protocol assignments
+  bl.addSubnet('192.0.2.0', 24); // TEST-NET-1
+  bl.addSubnet('192.168.0.0', 16); // RFC1918
+  bl.addSubnet('198.18.0.0', 15); // benchmarking
+  bl.addSubnet('198.51.100.0', 24); // TEST-NET-2
+  bl.addSubnet('203.0.113.0', 24); // TEST-NET-3
+  bl.addSubnet('224.0.0.0', 4); // multicast
+  bl.addSubnet('240.0.0.0', 4); // reserved
+  bl.addAddress('255.255.255.255'); // broadcast
+  // IPv6
+  bl.addAddress('::', 'ipv6'); // unspecified
+  bl.addAddress('::1', 'ipv6'); // loopback
+  bl.addSubnet('fc00::', 7, 'ipv6'); // unique local
+  bl.addSubnet('fe80::', 10, 'ipv6'); // link-local
+  bl.addSubnet('ff00::', 8, 'ipv6'); // multicast
+  bl.addSubnet('64:ff9b::', 96, 'ipv6'); // v4/v6 translation
+  bl.addSubnet('2001:db8::', 32, 'ipv6'); // documentation
+  return bl;
+};
+
+const blocklist = buildBlockList();
+
+// An error type the middleware can recognise to return HTTP 400 rather than 500.
+export class UnsafeTargetError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'UnsafeTargetError';
+    this.code = 'UNSAFE_TARGET';
+  }
+}
+
+// Reject anything that resolves to (or literally is) a private/reserved address.
+const checkAddress = (address) => {
+  const family = isIP(address) === 6 ? 'ipv6' : 'ipv4';
+  return !blocklist.check(address, family);
+};
+
+// Resolve `hostname` and ensure none of the returned addresses are private.
+// We check *all* addresses (not just the first) to defeat DNS records that
+// mix a public and a private answer.
+const resolveAndCheck = async (hostname) => {
+  if (isIP(hostname)) {
+    if (!checkAddress(hostname)) {
+      throw new UnsafeTargetError(
+        `Target ${hostname} resolves to a private or reserved address and is not allowed.`,
+      );
+    }
+    return;
+  }
+  let addresses;
+  try {
+    addresses = await dns.lookup(hostname, { all: true });
+  } catch {
+    // Let the downstream handler surface the DNS failure in its usual envelope.
+    return;
+  }
+  for (const { address } of addresses) {
+    if (!checkAddress(address)) {
+      throw new UnsafeTargetError(
+        `Target ${hostname} resolves to a private or reserved address (${address}) and is not allowed.`,
+      );
+    }
+  }
+};
+
+// Public entry point — called by the middleware before invoking any handler.
+// Throws `UnsafeTargetError` for disallowed targets; returns silently otherwise.
+export const assertSafeTarget = async (rawUrl) => {
+  if (ALLOW_PRIVATE) return;
+
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new UnsafeTargetError(`Invalid URL: ${rawUrl}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new UnsafeTargetError(
+      `Unsupported URL scheme "${parsed.protocol}". Only http and https are allowed.`,
+    );
+  }
+
+  // `URL` brackets IPv6 hostnames — strip them before passing to net/dns.
+  const hostname = parsed.hostname.replace(/^\[|]$/g, '');
+  if (!hostname) {
+    throw new UnsafeTargetError('URL is missing a hostname.');
+  }
+
+  await resolveAndCheck(hostname);
+};
+
+export default assertSafeTarget;


### PR DESCRIPTION
## Summary

The shared API middleware (`api/_common/middleware.js`) accepts a user-supplied `?url=` query parameter and hands it to every downstream handler (`fetch`, headless Chromium, raw `net`/`dns` calls, etc.) without checking whether the target is public. On the hosted instance at `web-check.xyz` — and on any self-hosted deployment that doesn't sit behind its own network policy — this lets an unauthenticated visitor use the API to reach the operator's private network.

That is a classic Server-Side Request Forgery (**CWE-918**). This PR adds a single, centralised guard in the middleware so every one of the 35 API handlers is protected in one place.

There are two prior community PRs on the same issue (#274 and #288), both still open. This PR takes a smaller, more surgical approach: no changes to individual handlers, one new file, one hook added to the middleware, one opt-out env var.

## Vulnerability details

- **Class:** Server-Side Request Forgery (CWE-918)
- **Entry point:** `commonMiddleware` in `api/_common/middleware.js` — used by all 35 endpoints (`api/*.js`) on both the Vercel/Node and Netlify code paths
- **Trust model:** the public instance and the default self-hosted config have no authentication; the attacker is any internet visitor
- **Reachable sinks (examples):**
  - `api/screenshot.js` → headless Chromium navigation to the target URL
  - `api/http-security.js`, `api/headers.js`, `api/redirects.js`, `api/hsts.js`, `api/cookies.js`, `api/carbon.js`, `api/quality.js`, `api/social-tags.js`, `api/robots-txt.js`, `api/security-txt.js`, `api/sitemap.js`, `api/archives.js`, `api/linked-pages.js`, `api/tech-stack.js` → `fetch()` / `axios` to the target
  - `api/tls-connection.js`, `api/ports.js` → raw `net.connect()` to arbitrary host:port
  - `api/dns.js`, `api/dnssec.js`, `api/mail-config.js`, `api/txt-records.js`, `api/dns-server.js` → DNS lookups against the target
- **Impact:** an unauthenticated attacker can enumerate the operator's internal network, read cloud instance metadata (169.254.169.254 → IAM credentials on AWS/GCP/Azure), probe TCP ports on internal services, and — via the response bodies rendered in the UI — often exfiltrate the results.

## Proof of concept

Before the fix, against any web-check instance (public or default self-hosted):

```bash
# 1. Cloud instance metadata — steals IAM credentials on AWS/GCP/Azure
curl 'https://<host>/api/headers?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/'

# 2. Loopback service enumeration — probes admin panels bound to localhost
curl 'https://<host>/api/http-security?url=http://127.0.0.1:8080/'
curl 'https://<host>/api/tls-connection?url=http://127.0.0.1:5432/'

# 3. Internal LAN scan — reaches RFC1918 space from the app server
curl 'https://<host>/api/headers?url=http://10.0.0.5/admin'

# 4. Filter-bypass forms that catch naive allow/deny-list guards
curl 'https://<host>/api/headers?url=http://2130706433/'          # decimal-encoded 127.0.0.1
curl 'https://<host>/api/headers?url=http://0x7f000001/'          # hex-encoded 127.0.0.1
curl 'https://<host>/api/headers?url=http://127.1/'               # short-form 127.0.0.1
curl 'https://<host>/api/headers?url=http://%5B%3A%3A1%5D/'       # IPv6 loopback [::1]
curl 'https://<host>/api/headers?url=http://localtest.me/'        # public DNS name → 127.0.0.1
```

Each of these previously reached the internal target and returned useful data (headers, TLS handshake result, HTML body, etc.) to the anonymous caller. After this PR every one of them returns `HTTP 400` with `{"error":"Target ... resolves to a private or reserved address and is not allowed."}`.

## The fix

One new file, one hook in the middleware, one opt-out env var. Total diff: **+156 lines, -0 lines** across 3 files.

**`api/_common/safe-target.js`** — new module that exports `assertSafeTarget(url)`. It:

1. Parses the URL and rejects non-`http`/`https` schemes (blocks `file:`, `gopher:`, `ftp:`, `dict:` and friends — the usual SSRF-to-something-else pivots).
2. Extracts the hostname (handling IPv6 brackets from the `URL` parser).
3. If the hostname is an IP literal, checks it directly. Otherwise resolves it via `dns.lookup(..., { all: true })` and checks **every** returned address (so a DNS record that mixes a public and a private answer is still rejected).
4. Uses Node's built-in `net.BlockList` seeded from the IANA special-purpose registries: RFC1918, loopback, link-local, CGNAT, multicast, broadcast, TEST-NET, benchmarking, IPv6 unique-local, IPv6 link-local, IPv6 documentation, `64:ff9b::/96` v4/v6 translation, and IPv4-mapped IPv6 addresses (via Node's built-in v4-mapping semantics — a subtle point noted in the code comments).

**`api/_common/middleware.js`** — 20 lines added. `assertSafeTarget(url)` is `await`ed after `normalizeUrl(url)` on both the Vercel/Node and Netlify branches. If it throws `UnsafeTargetError`, the middleware returns `HTTP 400` with the error message; anything else propagates as before. No handler needs to be touched — the guard runs before `handler(url, ...)` is called.

**`.env.sample`** — documents the new `ALLOW_PRIVATE_TARGETS=true` opt-out for self-hosters who legitimately want to scan their own LAN.

## Testing

Ran the module directly against 20 representative inputs covering every documented SSRF filter-bypass class. All 20 behave as expected:

```
PASS  reject -> reject  file:///etc/passwd
PASS  reject -> reject  gopher://127.0.0.1:6379/_INFO
PASS  reject -> reject  ftp://internal/
PASS  reject -> reject  http://169.254.169.254/latest/meta-data/
PASS  reject -> reject  http://127.0.0.1/
PASS  reject -> reject  http://10.0.0.5/
PASS  reject -> reject  http://192.168.1.1/
PASS  reject -> reject  http://172.16.5.5/
PASS  reject -> reject  http://100.64.0.1/                  (CGNAT)
PASS  reject -> reject  http://127.1/                       (short-form)
PASS  reject -> reject  http://2130706433/                  (decimal encoding)
PASS  reject -> reject  http://0x7f000001/                  (hex encoding)
PASS  reject -> reject  http://0177.0.0.1/                  (octal encoding)
PASS  reject -> reject  http://[::1]/                       (IPv6 loopback)
PASS  reject -> reject  http://[::ffff:127.0.0.1]/          (v4-mapped v6)
PASS  reject -> reject  http://[fe80::1]/                   (link-local v6)
PASS  reject -> reject  http://[fc00::1]/                   (unique-local v6)
PASS  reject -> reject  http://localtest.me/                (public DNS → 127.0.0.1)
PASS  allow  -> allow   https://example.com/
PASS  allow  -> allow   http://1.1.1.1/

20 passed, 0 failed
```

Setting `ALLOW_PRIVATE_TARGETS=true` and rerunning flips every reject to allow, so the self-host escape hatch works.

## Design notes for reviewers

- **Why one central guard, not per-handler patches?** Every endpoint in `api/*.js` is defined as `export const handler = middleware(myHandler)`. The middleware already owns URL normalisation (`normalizeUrl`). Adding the check there covers all 35 handlers with one hook and no risk of the next new endpoint forgetting it.
- **Why `dns.lookup` with `all: true`?** Because a DNS record can return multiple A/AAAA answers, and the handler will use whichever the OS resolver picks. Checking only the first address is a race condition. Checking all of them isn't a full DNS-rebinding fix — the guard resolves once and the handler resolves again (TOCTOU) — but it defeats the naive "return public + private in the same answer" trick and is the strongest correctness we can add without wrapping every HTTP client's socket dispatch.
- **Why `net.BlockList` rather than a hand-rolled comparator?** It's part of core Node, handles v4-mapped v6 correctly out of the box, and makes the address list read like the IANA registry it's derived from.
- **Backwards compatibility.** Self-hosters who scan their own LAN today (a real use case for a personal OSINT dashboard) set `ALLOW_PRIVATE_TARGETS=true` and get the pre-patch behaviour verbatim. Everyone else gets a 400 for private targets and no other observable change.
- **Known residual gaps this PR does not close.** Handlers that follow redirects (`api/redirects.js`) or recurse into child URLs (`api/sitemap.js` walks sitemap children) can still re-fetch a URL that wasn't run through the guard. Full DNS-rebinding protection would require pinning the resolved address for the actual fetch (custom `lookup` on every HTTP agent). Both are legitimate follow-ups that don't diminish the value of closing the primary attack surface here.

## Adversarial review

Before submitting, I tried to disprove this finding. The obvious "is it really unauthenticated?" question: yes — there is no auth middleware anywhere in `api/_common/`, `SECURITY.md` doesn't exist, `web-check.xyz` is a public instance, and every existing PR/issue on the repo treats the API as reachable by anonymous users. The "does an existing mitigation catch this?" question: I searched for any URL validation upstream of `commonMiddleware` and there is none — `normalizeUrl` only prepends `https://` and brackets IPv6, it does not check the target. The "is the operator already the attacker's peer on the network?" question: no — a self-hosted personal instance still exposes the operator's LAN (router admin UI, NAS, printers) to any visitor who knows the URL. The public hosted instance runs on cloud infrastructure whose metadata endpoint sits at `169.254.169.254`. Preconditions to exploit (be a public visitor) are strictly weaker than the capability granted (internal network read), so the fix meaningfully raises the bar.

Two prior PRs (#274 and #288) attempted the same fix. This one is intentionally smaller — one new file, no changes to any handler, a single opt-out env var — to make it easier to review and merge.