### PR TITLE
Small accuracy improvments

### DIFF
--- a/api/_common/middleware.js
+++ b/api/_common/middleware.js
@@ -26,7 +26,6 @@ if (process.env.PLATFORM) {
 // Define the headers to be returned with each response
 const headers = {
   'Access-Control-Allow-Origin': ALLOWED_ORIGINS,
-  'Access-Control-Allow-Credentials': true,
   'Content-Type': 'application/json;charset=UTF-8',
 };
 

--- a/api/archives.js
+++ b/api/archives.js
@@ -11,7 +11,7 @@ const convertTimestampToDate = (timestamp) => {
     timestamp.slice(12, 14),
   ].map((num) => parseInt(num, 10));
 
-  return new Date(year, month, day, hour, minute, second);
+  return new Date(Date.UTC(year, month, day, hour, minute, second));
 };
 
 const countPageChanges = (results) => {

--- a/api/firewall.js
+++ b/api/firewall.js
@@ -3,106 +3,47 @@ import { httpGet } from './_common/http.js';
 import { parseTarget } from './_common/parse-target.js';
 import { upstreamError } from './_common/upstream.js';
 
-const hasWaf = (waf) => ({ hasWaf: true, waf });
+// WAF signatures as [header, needle, name], a null needle matches any value
+const WAF_SIGNATURES = [
+  ['server', 'cloudflare', 'Cloudflare'],
+  ['x-powered-by', 'AWS Lambda', 'AWS WAF'],
+  ['server', 'AkamaiGHost', 'Akamai'],
+  ['server', 'Sucuri', 'Sucuri'],
+  ['server', 'BarracudaWAF', 'Barracuda WAF'],
+  ['server', 'BIG-IP', 'F5 BIG-IP'],
+  ['x-sucuri-id', null, 'Sucuri CloudProxy WAF'],
+  ['x-sucuri-cache', null, 'Sucuri CloudProxy WAF'],
+  ['server', 'FortiWeb', 'Fortinet FortiWeb WAF'],
+  ['server', 'Imperva', 'Imperva SecureSphere WAF'],
+  ['x-protected-by', 'Sqreen', 'Sqreen'],
+  ['x-waf-event-info', null, 'Reblaze WAF'],
+  ['set-cookie', '_citrix_ns_id', 'Citrix NetScaler'],
+  ['x-denied-reason', null, 'WangZhanBao WAF'],
+  ['x-wzws-requested-method', null, 'WangZhanBao WAF'],
+  ['x-webcoment', null, 'Webcoment Firewall'],
+  ['server', 'Yundun', 'Yundun WAF'],
+  ['x-yd-waf-info', null, 'Yundun WAF'],
+  ['x-yd-info', null, 'Yundun WAF'],
+  ['server', 'Safe3WAF', 'Safe3 Web Application Firewall'],
+  ['server', 'NAXSI', 'NAXSI WAF'],
+  ['x-datapower-transactionid', null, 'IBM WebSphere DataPower'],
+  ['server', 'QRATOR', 'QRATOR WAF'],
+  ['server', 'ddos-guard', 'DDoS-Guard WAF'],
+];
+
+// Match a header value (string or array) against a needle
+const matches = (value, needle) => {
+  if (!value) return false;
+  const values = Array.isArray(value) ? value : [value];
+  return values.some((v) => !needle || String(v).includes(needle));
+};
 
 const firewallHandler = async (url) => {
   const { href } = parseTarget(url);
   try {
-    const response = await httpGet(href, {
-      validateStatus: () => true,
-    });
-    const headers = response.headers;
-
-    if (headers['server'] && headers['server'].includes('cloudflare')) {
-      return hasWaf('Cloudflare');
-    }
-
-    if (headers['x-powered-by'] && headers['x-powered-by'].includes('AWS Lambda')) {
-      return hasWaf('AWS WAF');
-    }
-
-    if (headers['server'] && headers['server'].includes('AkamaiGHost')) {
-      return hasWaf('Akamai');
-    }
-
-    if (headers['server'] && headers['server'].includes('Sucuri')) {
-      return hasWaf('Sucuri');
-    }
-
-    if (headers['server'] && headers['server'].includes('BarracudaWAF')) {
-      return hasWaf('Barracuda WAF');
-    }
-
-    if (
-      headers['server'] &&
-      (headers['server'].includes('F5 BIG-IP') || headers['server'].includes('BIG-IP'))
-    ) {
-      return hasWaf('F5 BIG-IP');
-    }
-
-    if (headers['x-sucuri-id'] || headers['x-sucuri-cache']) {
-      return hasWaf('Sucuri CloudProxy WAF');
-    }
-
-    if (headers['server'] && headers['server'].includes('FortiWeb')) {
-      return hasWaf('Fortinet FortiWeb WAF');
-    }
-
-    if (headers['server'] && headers['server'].includes('Imperva')) {
-      return hasWaf('Imperva SecureSphere WAF');
-    }
-
-    if (headers['x-protected-by'] && headers['x-protected-by'].includes('Sqreen')) {
-      return hasWaf('Sqreen');
-    }
-
-    if (headers['x-waf-event-info']) {
-      return hasWaf('Reblaze WAF');
-    }
-
-    if (headers['set-cookie'] && headers['set-cookie'].includes('_citrix_ns_id')) {
-      return hasWaf('Citrix NetScaler');
-    }
-
-    if (headers['x-denied-reason'] || headers['x-wzws-requested-method']) {
-      return hasWaf('WangZhanBao WAF');
-    }
-
-    if (headers['x-webcoment']) {
-      return hasWaf('Webcoment Firewall');
-    }
-
-    if (headers['server'] && headers['server'].includes('Yundun')) {
-      return hasWaf('Yundun WAF');
-    }
-
-    if (headers['x-yd-waf-info'] || headers['x-yd-info']) {
-      return hasWaf('Yundun WAF');
-    }
-
-    if (headers['server'] && headers['server'].includes('Safe3WAF')) {
-      return hasWaf('Safe3 Web Application Firewall');
-    }
-
-    if (headers['server'] && headers['server'].includes('NAXSI')) {
-      return hasWaf('NAXSI WAF');
-    }
-
-    if (headers['x-datapower-transactionid']) {
-      return hasWaf('IBM WebSphere DataPower');
-    }
-
-    if (headers['server'] && headers['server'].includes('QRATOR')) {
-      return hasWaf('QRATOR WAF');
-    }
-
-    if (headers['server'] && headers['server'].includes('ddos-guard')) {
-      return hasWaf('DDoS-Guard WAF');
-    }
-
-    return {
-      hasWaf: false,
-    };
+    const { headers } = await httpGet(href, { validateStatus: () => true });
+    const match = WAF_SIGNATURES.find(([header, needle]) => matches(headers[header], needle));
+    return match ? { hasWaf: true, waf: match[2] } : { hasWaf: false };
   } catch (error) {
     return upstreamError(error, 'Firewall check');
   }

--- a/api/ports.js
+++ b/api/ports.js
@@ -81,7 +81,7 @@ const portsHandler = async (url, event, context) => {
   }
 
   if (timeoutReached) {
-    return errorResponse('The function timed out before completing.');
+    return { error: 'The function timed out before completing.' };
   }
 
   // Sort openPorts and failedPorts before returning
@@ -89,10 +89,6 @@ const portsHandler = async (url, event, context) => {
   failedPorts.sort((a, b) => a - b);
 
   return { openPorts, failedPorts };
-};
-
-const errorResponse = (message, statusCode = 444) => {
-  return { error: message };
 };
 
 export const handler = middleware(portsHandler);

--- a/api/subdomains.js
+++ b/api/subdomains.js
@@ -64,19 +64,19 @@ const subdomainsHandler = async (url) => {
   }
 
   const suffix = `.${domain}`;
-  const sieve = (names) => [
-    ...new Set(
-      names
-        .filter((n) => typeof n === 'string')
-        .map((n) => n.trim().toLowerCase().replace(/^\*\./, ''))
-        .filter((n) => n && n !== domain && n.endsWith(suffix) && HOSTNAME_RE.test(n)),
-    ),
-  ].sort();
+  const sieve = (names) =>
+    [
+      ...new Set(
+        names
+          .filter((n) => typeof n === 'string')
+          .map((n) => n.trim().toLowerCase().replace(/^\*\./, ''))
+          .filter((n) => n && n !== domain && n.endsWith(suffix) && HOSTNAME_RE.test(n)),
+      ),
+    ].sort();
 
   let succeeded = 0;
   const errors = [];
   for (const source of SOURCES) {
-    if (source.requires && !process.env[source.requires]) continue;
     try {
       const subdomains = sieve(await source.lookup(domain));
       succeeded += 1;

--- a/api/threats.js
+++ b/api/threats.js
@@ -45,7 +45,7 @@ const urlHaus = async (url) => {
 
 const phishTank = async (url) => {
   try {
-    const encoded = Buffer.from(url).toString('base64');
+    const encoded = encodeURIComponent(Buffer.from(url).toString('base64'));
     const res = await httpPost(`https://checkurl.phishtank.com/checkurl/?url=${encoded}`, null, {
       headers: { 'User-Agent': 'phishtank/web-check' },
       timeout: 3000,

--- a/netlify.toml
+++ b/netlify.toml
@@ -20,11 +20,11 @@
   # REACT_APP_SHODAN_API_KEY='' # Shodan API key, for using Shodan scan API
   # REACT_APP_WHO_API_KEY=''    # WhoAPI key, for iniiating client-side whois lookup
 
-# Redirect the /api/* path to the lambda functions
+# Rewrite the /api/* path to the lambda functions
 [[redirects]]
   from = "/api/*"
   to = "/.netlify/functions/:splat"
-  status = 301
+  status = 200
   force = true
 
 # Plugins

--- a/src/client/analysis/rules/cookies.ts
+++ b/src/client/analysis/rules/cookies.ts
@@ -1,14 +1,17 @@
 import type { Analyzer } from '../types';
 
-// Parse Set-Cookie headers (one per array element) into name + attribute list
+// Parse Set-Cookie headers (one per array element) into name + attribute list,
+// skipping nameless entries (empty lines, cookie-deletion stubs like "=; Path=/")
 const parseCookies = (raw: unknown): Array<{ name: string; attrs: string[] }> => {
   if (!Array.isArray(raw)) return [];
-  return raw.map((line) => {
-    const parts = String(line).split(/;\s*/);
-    const name = parts[0]?.split('=')[0]?.trim() || 'cookie';
-    const attrs = parts.slice(1).map((p) => p.split('=')[0].trim().toLowerCase());
-    return { name, attrs };
-  });
+  return raw
+    .map((line) => {
+      const parts = String(line).split(/;\s*/);
+      const name = parts[0].split('=')[0].trim();
+      const attrs = parts.slice(1).map((p) => p.split('=')[0].trim().toLowerCase());
+      return { name, attrs };
+    })
+    .filter((c) => c.name);
 };
 
 // Audit Set-Cookie attributes for Secure, HttpOnly, SameSite

--- a/src/client/analysis/rules/cookies.ts
+++ b/src/client/analysis/rules/cookies.ts
@@ -1,18 +1,14 @@
 import type { Analyzer } from '../types';
 
-// Parse Set-Cookie headers into name + attribute map (analysis-local copy)
+// Parse Set-Cookie headers (one per array element) into name + attribute list
 const parseCookies = (raw: unknown): Array<{ name: string; attrs: string[] }> => {
   if (!Array.isArray(raw)) return [];
-  return raw.flatMap((line) =>
-    String(line)
-      .split(/,(?=\s[A-Za-z0-9]+=)/)
-      .map((cookie) => {
-        const parts = cookie.split('; ').map((p) => p.trim());
-        const name = parts[0]?.split('=')[0] || 'cookie';
-        const attrs = parts.slice(1).map((p) => p.split('=')[0].toLowerCase());
-        return { name, attrs };
-      }),
-  );
+  return raw.map((line) => {
+    const parts = String(line).split(/;\s*/);
+    const name = parts[0]?.split('=')[0]?.trim() || 'cookie';
+    const attrs = parts.slice(1).map((p) => p.split('=')[0].trim().toLowerCase());
+    return { name, attrs };
+  });
 };
 
 // Audit Set-Cookie attributes for Secure, HttpOnly, SameSite

--- a/src/client/analysis/rules/mail-config.ts
+++ b/src/client/analysis/rules/mail-config.ts
@@ -54,8 +54,10 @@ const mailConfig: Analyzer = (d) => {
     }
   }
 
-  // DKIM detection is best-effort: only flag absence as a soft warning
-  const hasDkim = txt.some((r: string[]) => Array.isArray(r) && /v=DKIM1/i.test(r.join('')));
+  // DKIM detection is best-effort: v= is optional so also accept a public key tag
+  const hasDkim = txt.some(
+    (r: string[]) => Array.isArray(r) && /v=DKIM1|(^|;)\s*p=[A-Za-z0-9+/]{20}/i.test(r.join('')),
+  );
   if (!hasDkim) {
     out.push({
       severity: 'warning',

--- a/src/client/analysis/rules/tls-security-audit.ts
+++ b/src/client/analysis/rules/tls-security-audit.ts
@@ -17,6 +17,9 @@ const GRADE_SEVERITY: Record<string, Severity> = {
 const RANK: Severity[] = ['pass', 'info', 'warning', 'issue', 'critical'];
 const rank = (s: Severity) => RANK.indexOf(s);
 
+// GRADE_SEVERITY keys are ordered best to worst
+const GRADES = Object.keys(GRADE_SEVERITY);
+
 // Surface the worst SSL Labs endpoint grade for this host
 const tlsSecurityAudit: Analyzer = (d) => {
   if (!d || !Array.isArray(d.endpoints) || !d.endpoints.length) return [];
@@ -29,10 +32,8 @@ const tlsSecurityAudit: Analyzer = (d) => {
   let worstGrade = grades[0];
   for (const g of grades) {
     const sev = GRADE_SEVERITY[g] || 'info';
-    if (rank(sev) > rank(severity)) {
-      severity = sev;
-      worstGrade = g;
-    }
+    if (rank(sev) > rank(severity)) severity = sev;
+    if (GRADES.indexOf(g) > GRADES.indexOf(worstGrade)) worstGrade = g;
   }
   if (severity === 'pass') {
     return [{ severity: 'pass', title: `SSL Labs grade ${worstGrade}` }];

--- a/src/client/analysis/rules/tls-security-audit.ts
+++ b/src/client/analysis/rules/tls-security-audit.ts
@@ -1,12 +1,14 @@
 import type { Analyzer, Severity } from '../types';
 
-// Map SSL Labs grade to severity. Labs uses A+/A/A-/B/C/T/F/M (no D/E)
+// Map SSL Labs grade to severity. Labs uses A+/A/A-/B/C/D/E/F/T/M
 const GRADE_SEVERITY: Record<string, Severity> = {
   'A+': 'pass',
   A: 'pass',
   'A-': 'pass',
   B: 'warning',
   C: 'issue',
+  D: 'issue',
+  E: 'critical',
   F: 'critical',
   T: 'critical',
   M: 'critical',
@@ -24,11 +26,14 @@ const tlsSecurityAudit: Analyzer = (d) => {
   }
   if (!grades.length) return [];
   let severity: Severity = 'pass';
+  let worstGrade = grades[0];
   for (const g of grades) {
     const sev = GRADE_SEVERITY[g] || 'info';
-    if (rank(sev) > rank(severity)) severity = sev;
+    if (rank(sev) > rank(severity)) {
+      severity = sev;
+      worstGrade = g;
+    }
   }
-  const worstGrade = grades.find((g) => GRADE_SEVERITY[g] === severity) || grades[0];
   if (severity === 'pass') {
     return [{ severity: 'pass', title: `SSL Labs grade ${worstGrade}` }];
   }

--- a/src/client/components/Form/Row.tsx
+++ b/src/client/components/Form/Row.tsx
@@ -99,30 +99,12 @@ const List = styled.ul`
   }
 `;
 
-const isValidDate = (date: any): boolean => {
-  // Checks if a date is within reasonable range
-  const isInRange = (date: Date): boolean => {
-    return date >= new Date('1995-01-01') && date <= new Date('2030-12-31');
-  };
-
-  // Check if input is a timestamp
-  if (typeof date === 'number') {
-    const timestampDate = new Date(date);
-    return !isNaN(timestampDate.getTime()) && isInRange(timestampDate);
-  }
-
-  // Check if input is a date string
-  if (typeof date === 'string') {
-    const dateStringDate = new Date(date);
-    return !isNaN(dateStringDate.getTime()) && isInRange(dateStringDate);
-  }
-
-  // Check if input is a Date object
-  if (date instanceof Date) {
-    return !isNaN(date.getTime()) && isInRange(date);
-  }
-
-  return false;
+// Only date-format strings that actually look like dates, not bare numbers
+const isDateLike = (value: any): boolean => {
+  if (typeof value !== 'string' || value.length < 8 || !/[-/: ]/.test(value)) return false;
+  const date = new Date(value);
+  if (isNaN(date.getTime())) return false;
+  return date >= new Date('1995-01-01') && date <= new Date('2030-12-31');
 };
 
 const formatDate = (dateString: string): string => {
@@ -132,8 +114,9 @@ const formatDate = (dateString: string): string => {
     year: 'numeric',
   }).format(new Date(dateString));
 };
+
 const formatValue = (value: any): string => {
-  if (isValidDate(new Date(value))) return formatDate(value);
+  if (isDateLike(value)) return formatDate(value);
   if (typeof value === 'boolean') return value ? '✅' : '❌';
   return value;
 };

--- a/src/client/components/Results/CarbonFootprint.tsx
+++ b/src/client/components/Results/CarbonFootprint.tsx
@@ -39,7 +39,10 @@ const CarbonCard = (props: { data: any; title: string; actionButtons: any }): JS
       {!carbons?.adjustedBytes && <p>Unable to calculate carbon footprint for host</p>}
       {carbons?.adjustedBytes > 0 && (
         <>
-          <Row lbl="HTML Initial Size" val={formatBytes(carbons.adjustedBytes)} />
+          {props.data.bytes > 0 && (
+            <Row lbl="HTML Initial Size" val={formatBytes(props.data.bytes)} />
+          )}
+          <Row lbl="Adjusted Transfer Size" val={formatBytes(carbons.adjustedBytes)} />
           <Row lbl="CO2 for Initial Load" val={formatGrams(carbons.co2.grid.grams)} />
           <Row lbl="Energy Usage for Load" val={formatKwh(carbons.energy)} />
           {cleanerThan > 0 && (

--- a/src/client/components/Results/Cookies.tsx
+++ b/src/client/components/Results/Cookies.tsx
@@ -9,7 +9,8 @@ export const parseHeaderCookies = (cookiesHeader: string[]): Cookie[] => {
       const [nameValuePair, ...attributePairs] = cookieString
         .split('; ')
         .map((part) => part.trim());
-      const [name, value] = nameValuePair.split('=');
+      const [name, ...valueParts] = nameValuePair.split('=');
+      const value = valueParts.join('=');
       const attributes: Record<string, string> = {};
       attributePairs.forEach((pair) => {
         const [attributeName, attributeValue = ''] = pair.split('=');
@@ -35,7 +36,7 @@ const CookiesCard = (props: { data: any; title: string; actionButtons: any }): J
         return (
           <ExpandableRow
             key={`header-cookie-${index}-${cookie.name}`}
-            lbl={cookie.name}
+            lbl={cookie.name || '(unnamed)'}
             val={cookie.value}
             rowList={attributes}
           />

--- a/src/client/components/Results/DnsSec.tsx
+++ b/src/client/components/Results/DnsSec.tsx
@@ -241,14 +241,19 @@ const DnsSecCard = (props: { data: any; title: string; actionButtons: any }): JS
               <>
                 <Row lbl={`${key} - Present?`} val="✅ Yes" />
                 {record.answer.map((answer: any, index: number) => {
-                  const keyData = parseDNSKeyData(answer.data);
-                  const dsData = parseDSData(answer.data);
-                  const label = keyData.flags && keyData.flags !== 'Unknown' ? keyData.flags : key;
+                  const parsed: any =
+                    answer.type === 48
+                      ? parseDNSKeyData(answer.data)
+                      : answer.type === 43
+                        ? parseDSData(answer.data)
+                        : {};
+                  const label = parsed.flags && parsed.flags !== 'Unknown' ? parsed.flags : key;
                   return (
                     <ExpandableRow
+                      key={`${key}-${index}`}
                       lbl={`Record #${index + 1}`}
                       val={label}
-                      rowList={makeAnswerList({ ...answer, ...keyData, ...dsData })}
+                      rowList={makeAnswerList({ ...answer, ...parsed })}
                       open
                     />
                   );

--- a/src/client/components/Results/Headers.tsx
+++ b/src/client/components/Results/Headers.tsx
@@ -11,7 +11,14 @@ const HeadersCard = (props: {
   return (
     <Card heading={props.title} styles="grid-row: span 2;" actionButtons={props.actionButtons}>
       {Object.keys(headers).map((header: string, index: number) => {
-        return <Row key={`header-${index}`} lbl={header} val={headers[header]} />;
+        const val = headers[header];
+        return (
+          <Row
+            key={`header-${index}`}
+            lbl={header}
+            val={Array.isArray(val) ? val.join(', ') : val}
+          />
+        );
       })}
     </Card>
   );

--- a/src/client/components/Results/Lighthouse.tsx
+++ b/src/client/components/Results/Lighthouse.tsx
@@ -15,13 +15,10 @@ interface Audit {
 }
 
 const makeValue = (audit: Audit) => {
-  let score = audit.score;
-  if (audit.displayValue) {
-    score = audit.displayValue;
-  } else if (audit.scoreDisplayMode) {
-    score = audit.score === 1 ? '✅ Pass' : '❌ Fail';
-  }
-  return score;
+  if (audit.displayValue) return audit.displayValue;
+  if (audit.score == null) return 'N/A';
+  if (audit.scoreDisplayMode === 'binary') return audit.score === 1 ? '✅ Pass' : '❌ Fail';
+  return audit.score;
 };
 
 const LighthouseCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
@@ -31,8 +28,8 @@ const LighthouseCard = (props: { data: any; title: string; actionButtons: any })
 
   return (
     <Card heading={props.title} actionButtons={props.actionButtons}>
-      {Object.keys(categories).map((title: string, index: number) => {
-        const scoreIds = categories[title].auditRefs.map((ref: { id: string }) => ref.id);
+      {Object.keys(categories).map((key: string, index: number) => {
+        const scoreIds = categories[key].auditRefs.map((ref: { id: string }) => ref.id);
         const scoreList = scoreIds.map((id: string) => {
           return {
             lbl: audits[id].title,
@@ -44,8 +41,8 @@ const LighthouseCard = (props: { data: any; title: string; actionButtons: any })
         return (
           <ExpandableRow
             key={`lighthouse-${index}`}
-            lbl={title}
-            val={processScore(categories[title].score)}
+            lbl={categories[key].title || key}
+            val={processScore(categories[key].score)}
             rowList={scoreList}
           />
         );

--- a/src/client/components/Results/Rank.tsx
+++ b/src/client/components/Results/Rank.tsx
@@ -21,8 +21,8 @@ span.val {
 const makeRankStats = (data: { date: string; rank: number }[]) => {
   const average = Math.round(data.reduce((acc, cur) => acc + cur.rank, 0) / data.length);
   const today = data[0].rank;
-  const yesterday = data[1].rank;
-  const percentageChange = ((today - yesterday) / yesterday) * 100;
+  const yesterday = data[1]?.rank;
+  const percentageChange = yesterday ? ((today - yesterday) / yesterday) * 100 : null;
   return {
     average,
     percentageChange,
@@ -78,10 +78,12 @@ const RankCard = (props: { data: any; title: string; actionButtons: any }): JSX.
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
       <div className="rank-average">{data[0].rank.toLocaleString()}</div>
-      <Row
-        lbl="Change since Yesterday"
-        val={`${percentageChange > 0 ? '+' : ''} ${percentageChange.toFixed(2)}%`}
-      />
+      {percentageChange != null && (
+        <Row
+          lbl="Change since Yesterday"
+          val={`${percentageChange > 0 ? '+' : ''} ${percentageChange.toFixed(2)}%`}
+        />
+      )}
       <Row lbl="Historical Average Rank" val={average.toLocaleString()} />
       <div className="chart-container">{Chart(chartData, data)}</div>
     </Card>

--- a/src/client/components/Results/Redirects.tsx
+++ b/src/client/components/Results/Redirects.tsx
@@ -31,7 +31,7 @@ const RedirectsCard = (props: { data: any; title: string; actionButtons: any }):
           <p className="redirect-count">
             Followed {count} redirect{count === 1 ? '' : 's'} when contacting host
           </p>
-          {chain.map((redirect: any, index: number) => (
+          {chain.slice(1).map((redirect: any, index: number) => (
             <Row lbl="" val="" key={index}>
               <span className="arrow-thing">↳</span> {redirect}
             </Row>

--- a/src/client/components/Results/Redirects.tsx
+++ b/src/client/components/Results/Redirects.tsx
@@ -20,21 +20,24 @@ const cardStyles = `
 `;
 
 const RedirectsCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
-  const redirects = props.data;
+  // The API chain includes the original URL as its first entry
+  const chain = props.data?.redirects || [];
+  const count = Math.max(chain.length - 1, 0);
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
-      {!redirects?.redirects.length && <Row lbl="" val="No redirects" />}
-      <p className="redirect-count">
-        Followed {redirects.redirects.length} redirect{redirects.redirects.length === 1 ? '' : 's'}{' '}
-        when contacting host
-      </p>
-      {redirects.redirects.map((redirect: any, index: number) => {
-        return (
-          <Row lbl="" val="" key={index}>
-            <span className="arrow-thing">↳</span> {redirect}
-          </Row>
-        );
-      })}
+      {!count && <Row lbl="" val="No redirects" />}
+      {count > 0 && (
+        <>
+          <p className="redirect-count">
+            Followed {count} redirect{count === 1 ? '' : 's'} when contacting host
+          </p>
+          {chain.map((redirect: any, index: number) => (
+            <Row lbl="" val="" key={index}>
+              <span className="arrow-thing">↳</span> {redirect}
+            </Row>
+          ))}
+        </>
+      )}
     </Card>
   );
 };

--- a/src/client/components/Results/ServerLocation.tsx
+++ b/src/client/components/Results/ServerLocation.tsx
@@ -47,17 +47,23 @@ const ServerLocationCard = (props: {
 
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
-      <Row lbl="City" val={`${postCode}, ${city}, ${region}`} />
-      <Row lbl="" val="">
-        <b>Country</b>
-        <CountryValue>
-          {country}
-          {countryCode && <Flag countryCode={countryCode} width={28} />}
-        </CountryValue>
-      </Row>
-      <Row lbl="Timezone" val={timezone} />
-      <Row lbl="Languages" val={languages} />
-      <Row lbl="Currency" val={`${currency} (${currencyCode})`} />
+      {(postCode || city || region) && (
+        <Row lbl="City" val={[postCode, city, region].filter(Boolean).join(', ')} />
+      )}
+      {country && (
+        <Row lbl="" val="">
+          <b>Country</b>
+          <CountryValue>
+            {country}
+            {countryCode && <Flag countryCode={countryCode} width={28} />}
+          </CountryValue>
+        </Row>
+      )}
+      {timezone && <Row lbl="Timezone" val={timezone} />}
+      {languages && <Row lbl="Languages" val={languages} />}
+      {currency && (
+        <Row lbl="Currency" val={currencyCode ? `${currency} (${currencyCode})` : currency} />
+      )}
       <MapRow>
         <LocationMap lat={coords.latitude} lon={coords.longitude} label={`Server (${isp})`} />
         <SmallText>

--- a/src/client/components/Results/Threats.tsx
+++ b/src/client/components/Results/Threats.tsx
@@ -23,7 +23,7 @@ const convertToDate = (dateString: string): string => {
   const [date, time] = dateString.split(' ');
   const [year, month, day] = date.split('-').map(Number);
   const [hour, minute, second] = time.split(':').map(Number);
-  const dateObject = new Date(year, month - 1, day, hour, minute, second);
+  const dateObject = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
   if (isNaN(dateObject.getTime())) {
     return dateString;
   }
@@ -43,7 +43,9 @@ const MalwareCard = (props: { data: any; title: string; actionButtons: any }): J
       {((cloudmersive && !cloudmersive.error) || safeBrowsing?.details) && (
         <Row
           lbl="Threat Type"
-          val={safeBrowsing?.details?.threatType || cloudmersive.WebsiteThreatType || 'None :)'}
+          val={
+            safeBrowsing?.details?.[0]?.threatType || cloudmersive.WebsiteThreatType || 'None :)'
+          }
         />
       )}
       {phishTank && !phishTank.error && (
@@ -84,7 +86,11 @@ const MalwareCard = (props: { data: any; title: string; actionButtons: any }): J
               { lbl: 'Date Added', val: convertToDate(urlResult.date_added) },
               { lbl: 'Threat Type', val: urlResult.threat },
               { lbl: 'Reported By', val: urlResult.reporter },
-              { lbl: 'Takedown Time', val: urlResult.takedown_time_seconds },
+              {
+                lbl: 'Takedown Time',
+                val:
+                  urlResult.takedown_time_seconds && `${urlResult.takedown_time_seconds} seconds`,
+              },
               { lbl: 'Larted', val: urlResult.larted },
               { lbl: 'Tags', val: (urlResult.tags || []).join(', ') },
               { lbl: 'Reference', val: urlResult.urlhaus_reference },

--- a/src/client/components/Results/TlsConnection.tsx
+++ b/src/client/components/Results/TlsConnection.tsx
@@ -4,8 +4,6 @@ import colors from 'client/styles/colors';
 
 const yesNo = (v: boolean) => (v ? '✅ Yes' : '❌ No');
 
-const ocspStatus = (v: boolean) => (v ? 'Yes' : 'Not enabled');
-
 const formatEphemeralKey = (k: any): string => {
   if (!k?.type) return '';
   const parts = [k.type];
@@ -34,7 +32,7 @@ const TlsConnectionCard = (props: {
       <Row lbl="OCSP Stapling" val="">
         <span className="lbl">OCSP Stapling</span>
         <span className="val" style={{ color: colors.info }}>
-          {d.ocspStapled ? 'ⓘ Present' : 'ⓘ Not Present'} — may impact visitor privacy
+          {d.ocspStapled ? 'ⓘ Present' : 'ⓘ Not Present (may impact visitor privacy)'}
         </span>
       </Row>
       <Row

--- a/src/client/components/Results/TlsSecurityAudit.tsx
+++ b/src/client/components/Results/TlsSecurityAudit.tsx
@@ -26,17 +26,19 @@ const hsts = (policy?: any): string => {
   return days >= 365 ? `✅ ${days} days${sub}` : `⚠️ ${days} days${sub} (recommend >= 365)`;
 };
 
+// SSL Labs renegSupport bits: 1 = insecure client-init, 2 = secure, 4 = secure client-init
 const reneg = (n?: number): string => {
-  if (!n) return '⚠️ Insecure';
+  if (!n) return '✅ Not supported';
+  if (n & 1) return '⚠️ Insecure client-initiated';
   const flags = [];
-  if (n & 1) flags.push('secure');
-  if (n & 2) flags.push('client-init');
-  if (n & 4) flags.push('server-required');
+  if (n & 2) flags.push('secure');
+  if (n & 4) flags.push('secure client-initiated');
+  if (n & 8) flags.push('server-required');
   return `✅ ${flags.join(', ') || 'unknown'}`;
 };
 
 const sessionResumption = (n?: number): string =>
-  n === 1 ? '✅ Tickets' : n === 2 ? '✅ Tickets (no client cert)' : '❌ Disabled';
+  n === 2 ? '✅ Supported' : n === 1 ? '⚠️ IDs returned, not resumed' : '❌ Not enabled';
 
 const compression = (n?: number): string => (n ? '⚠️ Supported (CRIME risk)' : '✅ Disabled');
 
@@ -71,7 +73,7 @@ const VULNS: Array<[string, string]> = [
   ['logjam', 'LOGJAM'],
   ['drownVulnerable', 'DROWN'],
   ['openSslCcs', 'OpenSSL CCS Injection'],
-  ['openSSLLuckyMinus20', 'Lucky13'],
+  ['openSSLLuckyMinus20', 'OpenSSL Padding Oracle'],
   ['bleichenbacher', 'ROBOT (Bleichenbacher)'],
   ['ticketbleed', 'Ticketbleed'],
 ];

--- a/src/client/components/Results/TlsSecurityAudit.tsx
+++ b/src/client/components/Results/TlsSecurityAudit.tsx
@@ -26,7 +26,7 @@ const hsts = (policy?: any): string => {
   return days >= 365 ? `✅ ${days} days${sub}` : `⚠️ ${days} days${sub} (recommend >= 365)`;
 };
 
-// SSL Labs renegSupport bits: 1 = insecure client-init, 2 = secure, 4 = secure client-init
+// renegSupport bits: 1 insecure client-init, 2 secure, 4 secure client-init, 8 required
 const reneg = (n?: number): string => {
   if (!n) return '✅ Not supported';
   if (n & 1) return '⚠️ Insecure client-initiated';

--- a/src/client/jobs/registry.ts
+++ b/src/client/jobs/registry.ts
@@ -48,7 +48,7 @@ const fetchAndProcess =
   (path: string, process: (raw: any) => any = (r) => r) =>
   async (ctx: JobContext) => {
     const target = path.includes('${ip}') ? ctx.ipAddress || '' : ctx.address;
-    const url = path.replace(/\$\{(ip|url)\}/g, target);
+    const url = path.replace(/\$\{(ip|url)\}/g, encodeURIComponent(target));
     const res = await fetch(`${ctx.api}/${url}`, { signal: ctx.signal });
     const raw = await parseJson(res);
     return raw?.error ? raw : process(raw);
@@ -234,7 +234,7 @@ export const jobs: JobSpec[] = [
   {
     id: 'dns-server',
     expectedAddressTypes: [...URL_ONLY],
-    cards: [card('dns-server', 'Server Info', ['server'], DnsServerCard)],
+    cards: [card('dns-server', 'DNS Server', ['server'], DnsServerCard)],
     fetcher: fetchAndProcess('dns-server?url=${url}'),
   },
   {

--- a/src/client/utils/result-processor.ts
+++ b/src/client/utils/result-processor.ts
@@ -1,5 +1,3 @@
-import type { RowProps } from 'client/components/Form/Row';
-
 export interface ServerLocation {
   city: string;
   region: string;
@@ -138,53 +136,8 @@ export interface TechnologyGroup {
   technologies: Technology[];
 }
 
-export const makeTechnologies = (response: any): TechnologyGroup[] => {
-  let flatArray = response.Results[0].Result.Paths.reduce(
-    (accumulator: any, obj: any) => accumulator.concat(obj.Technologies),
-    [],
-  );
-  let technologies = flatArray.reduce((groups: any, item: any) => {
-    let tag = item.Tag;
-    if (!groups[tag]) groups[tag] = [];
-    groups[tag].push(item);
-    return groups;
-  }, {});
-  return technologies;
-};
-
 export type Cookie = {
   name: string;
   value: string;
   attributes: Record<string, string>;
-};
-
-export const parseRobotsTxt = (content: string): { robots: RowProps[] } => {
-  const lines = content.split('\n');
-  const rules: RowProps[] = [];
-
-  lines.forEach((line) => {
-    line = line.trim(); // This removes trailing and leading whitespaces
-
-    let match = line.match(/^(Allow|Disallow):\s*(\S*)$/i);
-    if (match) {
-      const rule: RowProps = {
-        lbl: match[1],
-        val: match[2],
-      };
-
-      rules.push(rule);
-    } else {
-      match = line.match(/^(User-agent):\s*(\S*)$/i);
-      if (match) {
-        const rule: RowProps = {
-          lbl: match[1],
-          val: match[2],
-        };
-
-        rules.push(rule);
-      }
-    }
-  });
-
-  return { robots: rules };
 };

--- a/src/client/views/Results.tsx
+++ b/src/client/views/Results.tsx
@@ -77,13 +77,9 @@ const makeActionButtons = (title: string, refresh: () => void, showInfo: () => v
 const Results = (props: { address?: string }): JSX.Element => {
   const { urlToScan } = useParams();
   const address = props.address || urlToScan || '';
-  const [addressType, setAddressType] = useState<AddressType>('empt');
+  const addressType: AddressType = useMemo(() => determineAddressType(address), [address]);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalContent, setModalContent] = useState<ReactNode>(<></>);
-
-  useEffect(() => {
-    setAddressType(determineAddressType(address));
-  }, [address]);
 
   const { state: jobsState, retry, ipLookupError } = useJobs(address, addressType, jobs);
 

--- a/src/client/views/Results.tsx
+++ b/src/client/views/Results.tsx
@@ -75,14 +75,15 @@ const makeActionButtons = (title: string, refresh: () => void, showInfo: () => v
 );
 
 const Results = (props: { address?: string }): JSX.Element => {
-  const address = props.address || useParams().urlToScan || '';
+  const { urlToScan } = useParams();
+  const address = props.address || urlToScan || '';
   const [addressType, setAddressType] = useState<AddressType>('empt');
   const [modalOpen, setModalOpen] = useState(false);
   const [modalContent, setModalContent] = useState<ReactNode>(<></>);
 
   useEffect(() => {
-    if (addressType === 'empt') setAddressType(determineAddressType(address));
-  }, [address, addressType]);
+    setAddressType(determineAddressType(address));
+  }, [address]);
 
   const { state: jobsState, retry, ipLookupError } = useJobs(address, addressType, jobs);
 


### PR DESCRIPTION
TL;DR:
- Date formatter no longer turns short numbers ("0", "5") into dates on cards
- DNSSEC card showed wrong algorithm/key tag for every record, now parses by type
- TLS audit renegotiation was read backwards (safest state showed as insecure)
- Carbon card showed the weighted bytes as page size, now shows the real size
- Redirect count was off by one, "no redirects" case now actually shows
- Lighthouse no longer marks N/A audits as failed, uses proper category titles
- WAF detection rewritten as a signature table (smaller, fixes Citrix match)
- Advisory rules: SSL Labs D/E grades handled, DKIM found without v=DKIM1 tag
- Some small card fixes: threat type, location "undefined", cookie values, rank crash, unnamed cookies
- Dead code removed, query params encoded, CORS credentials header dropped