### PR TITLE
fix: include domain name in DNS server lookup error message

### DIFF
--- a/api/dns-server.js
+++ b/api/dns-server.js
@@ -18,7 +18,7 @@ const dnsHandler = async (url) => {
   try {
     nameservers = await dnsPromises.resolveNs(domain);
   } catch (error) {
-    return upstreamError(error, 'DNS server lookup');
+    return upstreamError(error, `DNS server lookup for ${domain}`);
   }
   const results = await Promise.all(
     nameservers.map(async (ns) => {

--- a/pr-body.txt
+++ b/pr-body.txt
@@ -1,0 +1,6 @@
+Adds a utility to detect non-routable (private/local) IP addresses and skips external API calls for them. Currently implemented for the Wayback Machine / archives check.
+
+- Added pi/_common/is-non-routable.js - utility to detect private IPv4 ranges (10.x, 172.16-31.x, 192.168.x, 127.x, 169.254.x, 0.x) and IPv6 (loopback, unique-local, link-local)
+- Modified pi/archives.js - skip Wayback Machine lookup for non-routable targets
+
+Closes #302

--- a/pr-body.txt
+++ b/pr-body.txt
@@ -1,6 +1,0 @@
-Adds a utility to detect non-routable (private/local) IP addresses and skips external API calls for them. Currently implemented for the Wayback Machine / archives check.
-
-- Added pi/_common/is-non-routable.js - utility to detect private IPv4 ranges (10.x, 172.16-31.x, 192.168.x, 127.x, 169.254.x, 0.x) and IPv6 (loopback, unique-local, link-local)
-- Modified pi/archives.js - skip Wayback Machine lookup for non-routable targets
-
-Closes #302


### PR DESCRIPTION
Improves the error message for DNS server lookup failures to include the domain being queried, making it easier to debug which hostname caused the issue.

Before: \DNS server lookup failed: queryNs ENODATA\
After: \DNS server lookup for example.com failed: queryNs ENODATA\

Closes #301