### PR TITLE
Add missing space in hero tagline (seewhat -> see what)

### DIFF
--- a/src/components/homepage/HeroForm.astro
+++ b/src/components/homepage/HeroForm.astro
@@ -14,7 +14,7 @@ import Screenshots from './Screenshots.astro';
     <div class="homepage-action-content">
       <h2>We give you X-Ray<br />Vision for your Website</h2>
       <h3>
-        In just 20 seconds, you can see
+        In just 20 seconds, you can see 
         <span>what attackers already know</span>
       </h3>
       <form name="live-start" autocomplete="off" action="/check" class="live-start" id="live-start">


### PR DESCRIPTION
Adds a missing space in the hero tagline so it reads "you can **see what** attackers already know" instead of "you can seewhat attackers already know".