### PR TITLE
Adds a Data Breach History check, via Have I Been Pwned

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -797,6 +797,28 @@ Knowing if a site is listed as a threat by any of these services can be useful f
 
 </details>
 <details>
+<summary><b>Data Breach History</b></summary>
+
+###### Description
+
+Checks whether the organisation behind the target domain has itself appeared in a catalogued data breach, using the public [Have I Been Pwned](https://haveibeenpwned.com) breach catalogue. For each incident it shows the date, how many accounts were affected, and which classes of data were exposed, ranked by how damaging they are — credentials and financial records first, plain identifiers last.
+
+Only the registrable domain is ever sent upstream. No email address, account or password is submitted, and this makes no claim about any individual user's data.
+
+###### Use Cases
+
+A breach in a service's own history tells you something no live scan can: that credentials belonging to this site have already circulated, and roughly when. That matters when judging whether password reuse, credential stuffing or account takeover is a live risk for its users, and it is useful background when assessing a vendor.
+
+Bear in mind entries are catalogued per organisation, so a clean result means only that no breach has been catalogued against this domain, not that none occurred. HIBP also flags some entries as unverified, fabricated, or sourced from spam lists and stealer malware, and those are marked as unconfirmed rather than presented as fact.
+
+###### Useful Links
+
+- [Have I Been Pwned](https://haveibeenpwned.com)
+- [HIBP API docs](https://haveibeenpwned.com/API/v3)
+- [Credential stuffing (OWASP)](https://owasp.org/www-community/attacks/Credential_stuffing)
+
+</details>
+<details>
 <summary><b>TLS Cipher Suites</b></summary>
 
 <img width="300" src="https://pixelflare.cc/alicia/web-check/wc-tls-cipher" align="right" />

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,25 @@ jobs:
       - name: 🔍 Run ESLint
         run: yarn lint
 
+  test:
+    name: 🧪 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Checkout Code
+        uses: actions/checkout@v6
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'yarn'
+
+      - name: 📦 Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: 🧪 Run Tests
+        run: yarn test
+
   typecheck:
     name: 🧷 Type Check
     runs-on: ubuntu-latest

--- a/api/_common/breach-history.js
+++ b/api/_common/breach-history.js
@@ -3,10 +3,11 @@
 // domain-level catalogue only — no account, email or password is ever sent.
 
 import psl from 'psl';
-import { httpGet } from './http.js';
+import { UA, httpGet } from './http.js';
 
 const HIBP_BREACHES = 'https://haveibeenpwned.com/api/v3/breaches';
 const HIBP_TIMEOUT = 8000;
+const REDIRECT_TIMEOUT = 5000;
 
 // HIBP data is published under CC BY 4.0, so attribution travels with the data
 export const HIBP_SOURCE = {
@@ -207,4 +208,40 @@ export const summariseBreaches = (breaches) => {
 export const fetchBreachesForDomain = async (domain) => {
   const res = await httpGet(HIBP_BREACHES, { params: { domain }, timeout: HIBP_TIMEOUT });
   return res.data;
+};
+
+// Whether a redirect landed on a genuinely different site, and so is worth a
+// second lookup: morele.pl 301s to morele.net, and the breach is catalogued
+// against morele.net, so checking only what the user typed reports it clean
+export const isDifferentSite = (scanned, destination) =>
+  Boolean(scanned && destination && destination.includes('.') && destination !== scanned);
+
+export const dedupeBreaches = (breaches) => {
+  const seen = new Set();
+  return breaches.filter((breach) => {
+    if (seen.has(breach.name)) return false;
+    seen.add(breach.name);
+    return true;
+  });
+};
+
+// Where the browser would actually end up. Best-effort: a site that refuses
+// HEAD, hangs or fails simply yields nothing, and the caller carries on with
+// the domain that was typed.
+export const resolveFinalDomain = async (url) => {
+  for (const method of ['HEAD', 'GET']) {
+    try {
+      const response = await fetch(url, {
+        method,
+        redirect: 'follow',
+        signal: AbortSignal.timeout(REDIRECT_TIMEOUT),
+        headers: { 'user-agent': UA },
+      });
+      if (!response.ok && method === 'HEAD') continue;
+      return registrableDomain(new URL(response.url || url).hostname);
+    } catch {
+      // fall through to the next method, then give up
+    }
+  }
+  return null;
 };

--- a/api/_common/breach-history.js
+++ b/api/_common/breach-history.js
@@ -1,0 +1,210 @@
+// Looks up whether the site's own operator has appeared in a catalogued data
+// breach, using the public Have I Been Pwned breach catalogue. This is the
+// domain-level catalogue only — no account, email or password is ever sent.
+
+import psl from 'psl';
+import { httpGet } from './http.js';
+
+const HIBP_BREACHES = 'https://haveibeenpwned.com/api/v3/breaches';
+const HIBP_TIMEOUT = 8000;
+
+// HIBP data is published under CC BY 4.0, so attribution travels with the data
+export const HIBP_SOURCE = {
+  name: 'Have I Been Pwned',
+  url: 'https://haveibeenpwned.com',
+  license: 'CC BY 4.0',
+  licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
+};
+
+// Anything that hands an attacker the account itself, money, or a legal identity
+const CRITICAL_CLASSES = new Set([
+  'passwords',
+  'historical passwords',
+  'security questions and answers',
+  'auth tokens',
+  'encrypted keys',
+  'pins',
+  'credit cards',
+  'credit card cvv',
+  'bank account numbers',
+  'government issued ids',
+  'passport numbers',
+  'social security numbers',
+  'biometric data',
+]);
+
+// Anything that makes a convincing targeted attack, or that is sensitive in law
+const HIGH_CLASSES = new Set([
+  'password hints',
+  'partial credit card data',
+  'dates of birth',
+  'physical addresses',
+  'phone numbers',
+  'private messages',
+  'email messages',
+  'chat logs',
+  'account balances',
+  'payment histories',
+  'health insurance information',
+  'sexual orientations',
+  'religions',
+  'political views',
+  'ethnicities',
+]);
+
+// Plain identifiers: unwelcome, but not directly actionable on their own
+const MEDIUM_CLASSES = new Set([
+  'email addresses',
+  'usernames',
+  'names',
+  'ip addresses',
+  'geographic locations',
+  'social media profiles',
+  'device information',
+  'browser user agent details',
+  'profile photos',
+  'avatars',
+]);
+
+const TIER_RANK = { critical: 0, high: 1, medium: 2, low: 3 };
+
+// Fold a hostname to the registrable domain, since HIBP indexes breaches that
+// way: querying store.adobe.com returns nothing, adobe.com returns the breach
+export const registrableDomain = (hostname) => {
+  if (!hostname || typeof hostname !== 'string') return '';
+  const host = hostname.trim().toLowerCase();
+  if (!host) return '';
+  try {
+    return psl.parse(host)?.domain || host;
+  } catch {
+    return host;
+  }
+};
+
+const ENTITIES = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#x27;': "'",
+  '&#39;': "'",
+  '&apos;': "'",
+  '&nbsp;': ' ',
+};
+
+// HIBP descriptions contain real markup (<em>, <a href>). Rendering third-party
+// HTML is precisely the flaw this tool reports on other people's sites, so the
+// tags come out here rather than being trusted downstream.
+export const stripHtml = (value) => {
+  if (typeof value !== 'string' || !value) return '';
+  return (
+    value
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/&[#a-z0-9]+;/gi, (entity) => ENTITIES[entity.toLowerCase()] ?? entity)
+      .replace(/\s+/g, ' ')
+      // A tag between a word and its punctuation leaves a gap: "exposed</a>."
+      .replace(/\s+([.,;:!?])/g, '$1')
+      .trim()
+  );
+};
+
+export const classifyDataClass = (name) => {
+  const key = typeof name === 'string' ? name.trim().toLowerCase() : '';
+  if (CRITICAL_CLASSES.has(key)) return 'critical';
+  if (HIGH_CLASSES.has(key)) return 'high';
+  if (MEDIUM_CLASSES.has(key)) return 'medium';
+  return 'low';
+};
+
+const toCount = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : null);
+
+const readDataClasses = (classes) => {
+  if (!Array.isArray(classes)) return [];
+  return classes
+    .filter((name) => typeof name === 'string' && name.trim())
+    .map((name) => ({ name, tier: classifyDataClass(name) }))
+    .sort((a, b) => TIER_RANK[a.tier] - TIER_RANK[b.tier]);
+};
+
+const worstTier = (dataClasses) =>
+  dataClasses.length
+    ? dataClasses.reduce(
+        (worst, c) => (TIER_RANK[c.tier] < TIER_RANK[worst] ? c.tier : worst),
+        'low',
+      )
+    : 'low';
+
+export const parseBreaches = (raw) => {
+  if (!Array.isArray(raw)) return [];
+
+  return raw.flatMap((entry) => {
+    if (!entry || typeof entry !== 'object') return [];
+    const name = entry.Name || entry.Title;
+    if (!name) return [];
+
+    const dataClasses = readDataClasses(entry.DataClasses);
+    const verified = entry.IsVerified === true;
+    const fabricated = entry.IsFabricated === true;
+    const spamList = entry.IsSpamList === true;
+
+    return [
+      {
+        name,
+        title: entry.Title || entry.Name,
+        domain: entry.Domain || null,
+        breachDate: entry.BreachDate || null,
+        addedDate: entry.AddedDate || null,
+        modifiedDate: entry.ModifiedDate || null,
+        accounts: toCount(entry.PwnCount),
+        description: stripHtml(entry.Description),
+        logo: entry.LogoPath || null,
+        dataClasses,
+        severity: worstTier(dataClasses),
+        verified,
+        fabricated,
+        spamList,
+        sensitive: entry.IsSensitive === true,
+        retired: entry.IsRetired === true,
+        malware: entry.IsMalware === true,
+        stealerLog: entry.IsStealerLog === true,
+        // Unverified, fabricated and spam-list entries are shown, but never
+        // presented with the same weight as a confirmed incident
+        trustworthy: verified && !fabricated && !spamList,
+      },
+    ];
+  });
+};
+
+const byRisk = (a, b) => {
+  if (a.trustworthy !== b.trustworthy) return a.trustworthy ? -1 : 1;
+  const tier = TIER_RANK[a.severity] - TIER_RANK[b.severity];
+  if (tier !== 0) return tier;
+  return (b.breachDate || '').localeCompare(a.breachDate || '');
+};
+
+export const sortBreaches = (breaches) => [...breaches].sort(byRisk);
+
+export const summariseBreaches = (breaches) => {
+  const counts = breaches.map((b) => b.accounts).filter((n) => n !== null);
+  const dates = breaches.map((b) => b.breachDate).filter(Boolean);
+  const tiers = breaches.map((b) => TIER_RANK[b.severity]);
+  const worst = tiers.length ? Math.min(...tiers) : null;
+
+  return {
+    total: breaches.length,
+    totalAccounts: counts.reduce((sum, n) => sum + n, 0),
+    worstSeverity:
+      worst === null ? null : Object.keys(TIER_RANK).find((k) => TIER_RANK[k] === worst),
+    latestBreachDate: dates.length ? dates.sort().at(-1) : null,
+    verifiedCount: breaches.filter((b) => b.verified).length,
+    unverifiedCount: breaches.filter((b) => !b.trustworthy).length,
+  };
+};
+
+// The catalogue is queried per domain rather than downloaded whole: a miss is a
+// two-byte response, which suits a serverless deploy far better than holding
+// the full 1.2 MB catalogue in memory on every cold start
+export const fetchBreachesForDomain = async (domain) => {
+  const res = await httpGet(HIBP_BREACHES, { params: { domain }, timeout: HIBP_TIMEOUT });
+  return res.data;
+};

--- a/api/_common/breach-history.test.js
+++ b/api/_common/breach-history.test.js
@@ -1,0 +1,294 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  registrableDomain,
+  stripHtml,
+  classifyDataClass,
+  parseBreaches,
+  sortBreaches,
+  summariseBreaches,
+} from './breach-history.js';
+
+// --- registrableDomain -------------------------------------------------------
+
+// HIBP indexes breaches against the registrable domain, so store.adobe.com has
+// to be folded down to adobe.com or the lookup silently returns nothing
+test('registrableDomain folds subdomains down to the registrable domain', () => {
+  assert.equal(registrableDomain('store.adobe.com'), 'adobe.com');
+  assert.equal(registrableDomain('adobe.com'), 'adobe.com');
+  assert.equal(registrableDomain('www.jcjk.pl'), 'jcjk.pl');
+});
+
+test('registrableDomain handles multi-part public suffixes', () => {
+  assert.equal(registrableDomain('shop.example.co.uk'), 'example.co.uk');
+  assert.equal(registrableDomain('example.co.uk'), 'example.co.uk');
+});
+
+test('registrableDomain lowercases the result', () => {
+  assert.equal(registrableDomain('ROBLOX.COM'), 'roblox.com');
+  assert.equal(registrableDomain('Store.Adobe.Com'), 'adobe.com');
+});
+
+test('registrableDomain falls back to the input when there is no public suffix', () => {
+  assert.equal(registrableDomain('localhost'), 'localhost');
+  assert.equal(registrableDomain(''), '');
+  assert.equal(registrableDomain(null), '');
+});
+
+// --- stripHtml ---------------------------------------------------------------
+
+// HIBP descriptions ship raw markup, and piping third-party HTML into the DOM
+// is the exact bug this tool exists to find on other people's sites
+test('stripHtml removes the markup HIBP embeds in descriptions', () => {
+  const raw =
+    'In October 2013, 153 million Adobe accounts were breached with each containing an ' +
+    'internal ID, username, email, <em>encrypted</em> password and a password hint in plain ' +
+    'text. The unencrypted hints also <a href="http://troyhunt.com/x" target="_blank" ' +
+    'rel="noopener">disclosed much about the passwords</a> adding further to the risk.';
+  const text = stripHtml(raw);
+  assert.ok(!text.includes('<'), 'no tags should survive');
+  assert.ok(!text.includes('href'), 'no attributes should survive');
+  assert.ok(text.includes('encrypted password'));
+  assert.ok(text.includes('disclosed much about the passwords'));
+});
+
+test('stripHtml decodes the entities that appear in HIBP copy', () => {
+  assert.equal(stripHtml('Ashley &amp; Madison'), 'Ashley & Madison');
+  assert.equal(stripHtml('&quot;quoted&quot;'), '"quoted"');
+  assert.equal(stripHtml('it&#x27;s'), "it's");
+  assert.equal(stripHtml('a&nbsp;b'), 'a b');
+  assert.equal(stripHtml('&lt;script&gt;'), '<script>');
+});
+
+test('stripHtml collapses the whitespace left behind by removed tags', () => {
+  assert.equal(stripHtml('<p>one</p>   <p>two</p>'), 'one two');
+});
+
+// A tag sitting between a word and its punctuation would otherwise leave the
+// gap behind: "...passwords exposed</a>." reading as "passwords exposed ."
+test('stripHtml does not leave a gap before punctuation', () => {
+  assert.equal(
+    stripHtml('email addresses and passwords <a href="#">exposed</a>.'),
+    'email addresses and passwords exposed.',
+  );
+  assert.equal(stripHtml('one <em>two</em> , three'), 'one two, three');
+  assert.equal(stripHtml('is it <b>so</b> ?'), 'is it so?');
+});
+
+test('stripHtml tolerates empty and non-string input', () => {
+  assert.equal(stripHtml(''), '');
+  assert.equal(stripHtml(null), '');
+  assert.equal(stripHtml(undefined), '');
+  assert.equal(stripHtml(42), '');
+});
+
+// --- classifyDataClass -------------------------------------------------------
+
+test('classifyDataClass treats credentials and financial data as critical', () => {
+  for (const cls of [
+    'Passwords',
+    'Historical passwords',
+    'Security questions and answers',
+    'Auth tokens',
+    'Credit cards',
+    'Bank account numbers',
+    'Government issued IDs',
+    'Passport numbers',
+  ]) {
+    assert.equal(classifyDataClass(cls), 'critical', cls);
+  }
+});
+
+test('classifyDataClass treats data enabling targeted attacks as high', () => {
+  for (const cls of [
+    'Password hints',
+    'Partial credit card data',
+    'Dates of birth',
+    'Physical addresses',
+    'Phone numbers',
+    'Private messages',
+  ]) {
+    assert.equal(classifyDataClass(cls), 'high', cls);
+  }
+});
+
+test('classifyDataClass treats plain identifiers as medium', () => {
+  for (const cls of ['Email addresses', 'Usernames', 'Names', 'IP addresses']) {
+    assert.equal(classifyDataClass(cls), 'medium', cls);
+  }
+});
+
+test('classifyDataClass defaults unknown classes to low rather than guessing', () => {
+  assert.equal(classifyDataClass('Spoken languages'), 'low');
+  assert.equal(classifyDataClass('Something HIBP added last week'), 'low');
+  assert.equal(classifyDataClass(''), 'low');
+  assert.equal(classifyDataClass(null), 'low');
+});
+
+// --- parseBreaches -----------------------------------------------------------
+
+const adobe = {
+  Name: 'Adobe',
+  Title: 'Adobe',
+  Domain: 'adobe.com',
+  BreachDate: '2013-10-04',
+  AddedDate: '2013-12-04T00:00:00Z',
+  ModifiedDate: '2022-05-15T23:52:49Z',
+  PwnCount: 152445165,
+  Description: 'In October 2013, <em>153 million</em> Adobe accounts were breached.',
+  LogoPath: 'https://logos.haveibeenpwned.com/Adobe.png',
+  DataClasses: ['Email addresses', 'Password hints', 'Passwords', 'Usernames'],
+  IsVerified: true,
+  IsFabricated: false,
+  IsSensitive: false,
+  IsRetired: false,
+  IsSpamList: false,
+  IsMalware: false,
+  IsStealerLog: false,
+};
+
+test('parseBreaches maps the HIBP record onto our shape', () => {
+  const [b] = parseBreaches([adobe]);
+  assert.equal(b.name, 'Adobe');
+  assert.equal(b.title, 'Adobe');
+  assert.equal(b.domain, 'adobe.com');
+  assert.equal(b.breachDate, '2013-10-04');
+  assert.equal(b.accounts, 152445165);
+  assert.equal(b.logo, 'https://logos.haveibeenpwned.com/Adobe.png');
+  assert.equal(b.verified, true);
+});
+
+test('parseBreaches strips the HTML out of the description', () => {
+  const [b] = parseBreaches([adobe]);
+  assert.equal(b.description, 'In October 2013, 153 million Adobe accounts were breached.');
+});
+
+test('parseBreaches tiers each data class and sorts the worst first', () => {
+  const [b] = parseBreaches([adobe]);
+  assert.deepEqual(b.dataClasses, [
+    { name: 'Passwords', tier: 'critical' },
+    { name: 'Password hints', tier: 'high' },
+    { name: 'Email addresses', tier: 'medium' },
+    { name: 'Usernames', tier: 'medium' },
+  ]);
+});
+
+test('parseBreaches derives breach severity from the worst data class', () => {
+  assert.equal(parseBreaches([adobe])[0].severity, 'critical');
+  const emailOnly = { ...adobe, DataClasses: ['Email addresses', 'Job titles'] };
+  assert.equal(parseBreaches([emailOnly])[0].severity, 'medium');
+  const nothing = { ...adobe, DataClasses: [] };
+  assert.equal(parseBreaches([nothing])[0].severity, 'low');
+});
+
+test('parseBreaches carries the flags that qualify how much a breach is worth trusting', () => {
+  const dubious = {
+    ...adobe,
+    IsVerified: false,
+    IsFabricated: true,
+    IsSpamList: true,
+    IsStealerLog: true,
+    IsMalware: true,
+    IsSensitive: true,
+    IsRetired: true,
+  };
+  const [b] = parseBreaches([dubious]);
+  assert.equal(b.verified, false);
+  assert.equal(b.fabricated, true);
+  assert.equal(b.spamList, true);
+  assert.equal(b.stealerLog, true);
+  assert.equal(b.malware, true);
+  assert.equal(b.sensitive, true);
+  assert.equal(b.retired, true);
+});
+
+test('parseBreaches marks unverified, fabricated or spam-list entries as not trustworthy', () => {
+  assert.equal(parseBreaches([adobe])[0].trustworthy, true);
+  assert.equal(parseBreaches([{ ...adobe, IsVerified: false }])[0].trustworthy, false);
+  assert.equal(parseBreaches([{ ...adobe, IsFabricated: true }])[0].trustworthy, false);
+  assert.equal(parseBreaches([{ ...adobe, IsSpamList: true }])[0].trustworthy, false);
+});
+
+test('parseBreaches returns [] for empty or malformed input', () => {
+  assert.deepEqual(parseBreaches([]), []);
+  assert.deepEqual(parseBreaches(null), []);
+  assert.deepEqual(parseBreaches(undefined), []);
+  assert.deepEqual(parseBreaches('nope'), []);
+  assert.deepEqual(parseBreaches([null, 'nope', 42]), []);
+});
+
+test('parseBreaches skips records with no identifying name', () => {
+  assert.deepEqual(parseBreaches([{ Domain: 'x.com', DataClasses: [] }]), []);
+});
+
+test('parseBreaches copes with a record missing every optional field', () => {
+  const [b] = parseBreaches([{ Name: 'Bare' }]);
+  assert.equal(b.name, 'Bare');
+  assert.equal(b.accounts, null);
+  assert.equal(b.breachDate, null);
+  assert.deepEqual(b.dataClasses, []);
+  assert.equal(b.severity, 'low');
+  assert.equal(b.description, '');
+});
+
+// --- sortBreaches ------------------------------------------------------------
+
+const make = (over) => parseBreaches([{ ...adobe, ...over }])[0];
+
+test('sortBreaches puts trustworthy breaches ahead of unverified ones', () => {
+  const sorted = sortBreaches([
+    make({ Name: 'Doubtful', IsVerified: false }),
+    make({ Name: 'Solid' }),
+  ]);
+  assert.deepEqual(
+    sorted.map((b) => b.name),
+    ['Solid', 'Doubtful'],
+  );
+});
+
+test('sortBreaches ranks by severity, then by most recent', () => {
+  const sorted = sortBreaches([
+    make({ Name: 'OldCreds', BreachDate: '2010-01-01' }),
+    make({ Name: 'RecentEmails', BreachDate: '2023-01-01', DataClasses: ['Email addresses'] }),
+    make({ Name: 'NewCreds', BreachDate: '2021-01-01' }),
+  ]);
+  assert.deepEqual(
+    sorted.map((b) => b.name),
+    ['NewCreds', 'OldCreds', 'RecentEmails'],
+  );
+});
+
+test('sortBreaches does not mutate its input', () => {
+  const list = [make({ Name: 'B', IsVerified: false }), make({ Name: 'A' })];
+  sortBreaches(list);
+  assert.equal(list[0].name, 'B');
+});
+
+// --- summariseBreaches -------------------------------------------------------
+
+test('summariseBreaches totals the incidents, accounts and worst severity', () => {
+  const summary = summariseBreaches([
+    make({ Name: 'One', PwnCount: 100, BreachDate: '2013-10-04' }),
+    make({ Name: 'Two', PwnCount: 50, BreachDate: '2019-02-01', DataClasses: ['Email addresses'] }),
+  ]);
+  assert.equal(summary.total, 2);
+  assert.equal(summary.totalAccounts, 150);
+  assert.equal(summary.worstSeverity, 'critical');
+  assert.equal(summary.latestBreachDate, '2019-02-01');
+  assert.equal(summary.verifiedCount, 2);
+});
+
+test('summariseBreaches ignores unknown account counts rather than treating them as zero', () => {
+  const summary = summariseBreaches([make({ PwnCount: null }), make({ PwnCount: 10 })]);
+  assert.equal(summary.totalAccounts, 10);
+});
+
+test('summariseBreaches reports a clean domain', () => {
+  const summary = summariseBreaches([]);
+  assert.equal(summary.total, 0);
+  assert.equal(summary.totalAccounts, 0);
+  assert.equal(summary.worstSeverity, null);
+  assert.equal(summary.latestBreachDate, null);
+  assert.equal(summary.verifiedCount, 0);
+});

--- a/api/_common/breach-history.test.js
+++ b/api/_common/breach-history.test.js
@@ -8,6 +8,8 @@ import {
   parseBreaches,
   sortBreaches,
   summariseBreaches,
+  isDifferentSite,
+  dedupeBreaches,
 } from './breach-history.js';
 
 // --- registrableDomain -------------------------------------------------------
@@ -263,6 +265,42 @@ test('sortBreaches does not mutate its input', () => {
   const list = [make({ Name: 'B', IsVerified: false }), make({ Name: 'A' })];
   sortBreaches(list);
   assert.equal(list[0].name, 'B');
+});
+
+// --- isDifferentSite ---------------------------------------------------------
+
+// morele.pl 301s to morele.net, and the breach is catalogued against
+// morele.net, so looking up only what the user typed reports a clean domain
+test('isDifferentSite spots a redirect that lands on another registrable domain', () => {
+  assert.equal(isDifferentSite('morele.pl', 'morele.net'), true);
+});
+
+test('isDifferentSite ignores redirects that stay on the same site', () => {
+  assert.equal(isDifferentSite('morele.net', 'morele.net'), false);
+  assert.equal(isDifferentSite('adobe.com', 'adobe.com'), false);
+});
+
+test('isDifferentSite ignores a missing or unusable destination', () => {
+  assert.equal(isDifferentSite('morele.pl', null), false);
+  assert.equal(isDifferentSite('morele.pl', ''), false);
+  assert.equal(isDifferentSite('morele.pl', 'localhost'), false);
+  assert.equal(isDifferentSite('', 'morele.net'), false);
+});
+
+// --- dedupeBreaches ----------------------------------------------------------
+
+test('dedupeBreaches keeps one entry per breach when both domains return it', () => {
+  const list = parseBreaches([adobe, { ...adobe, PwnCount: 1 }, { ...adobe, Name: 'Other' }]);
+  const deduped = dedupeBreaches(list);
+  assert.deepEqual(
+    deduped.map((b) => b.name),
+    ['Adobe', 'Other'],
+  );
+  assert.equal(deduped[0].accounts, 152445165, 'the first occurrence wins');
+});
+
+test('dedupeBreaches handles an empty list', () => {
+  assert.deepEqual(dedupeBreaches([]), []);
 });
 
 // --- summariseBreaches -------------------------------------------------------

--- a/api/breach-history.js
+++ b/api/breach-history.js
@@ -3,9 +3,12 @@ import { parseTarget } from './_common/parse-target.js';
 import { upstreamError } from './_common/upstream.js';
 import {
   HIBP_SOURCE,
+  dedupeBreaches,
   fetchBreachesForDomain,
+  isDifferentSite,
   parseBreaches,
   registrableDomain,
+  resolveFinalDomain,
   sortBreaches,
   summariseBreaches,
 } from './_common/breach-history.js';
@@ -24,9 +27,29 @@ const breachHistoryHandler = async (url) => {
   }
 
   try {
-    const breaches = sortBreaches(parseBreaches(await fetchBreachesForDomain(domain)));
+    // Where the browser ends up matters as much as what was typed: morele.pl
+    // 301s to morele.net, and the breach is catalogued against morele.net.
+    // Resolving the destination alongside the first lookup keeps it ~free.
+    const [primary, destination] = await Promise.all([
+      fetchBreachesForDomain(domain),
+      resolveFinalDomain(url),
+    ]);
+
+    // Both domains are reported, never merged into one identity: a parked
+    // domain pointing at a big site must not inherit that site's breaches
+    const redirectedTo = isDifferentSite(domain, destination) ? destination : null;
+    const secondary = redirectedTo
+      ? await fetchBreachesForDomain(redirectedTo).catch(() => [])
+      : [];
+
+    const breaches = sortBreaches(
+      dedupeBreaches([...parseBreaches(primary), ...parseBreaches(secondary)]),
+    );
+
     return {
       domain,
+      redirectedTo,
+      domainsChecked: redirectedTo ? [domain, redirectedTo] : [domain],
       breaches,
       summary: summariseBreaches(breaches),
       source: HIBP_SOURCE,

--- a/api/breach-history.js
+++ b/api/breach-history.js
@@ -1,0 +1,40 @@
+import middleware from './_common/middleware.js';
+import { parseTarget } from './_common/parse-target.js';
+import { upstreamError } from './_common/upstream.js';
+import {
+  HIBP_SOURCE,
+  fetchBreachesForDomain,
+  parseBreaches,
+  registrableDomain,
+  sortBreaches,
+  summariseBreaches,
+} from './_common/breach-history.js';
+
+const isIpAddress = (host) => /^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.includes(':');
+
+// Whether the operator of this domain has appeared in a catalogued data breach.
+// Only the domain is sent upstream — never an account, address or password.
+const breachHistoryHandler = async (url) => {
+  const { hostname } = parseTarget(url);
+  if (isIpAddress(hostname)) return { skipped: 'Breach history needs a domain, not an IP' };
+
+  const domain = registrableDomain(hostname);
+  if (!domain || !domain.includes('.')) {
+    return { skipped: 'Could not resolve a registrable domain to look up' };
+  }
+
+  try {
+    const breaches = sortBreaches(parseBreaches(await fetchBreachesForDomain(domain)));
+    return {
+      domain,
+      breaches,
+      summary: summariseBreaches(breaches),
+      source: HIBP_SOURCE,
+    };
+  } catch (error) {
+    return upstreamError(error, 'Breach history lookup');
+  }
+};
+
+export const handler = middleware(breachHistoryHandler);
+export default handler;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:astro": "PUBLIC_API_ENDPOINT=http://localhost:3001/api astro dev",
     "dev": "concurrently -c magenta,cyan -n backend,frontend 'yarn dev:api' 'yarn dev:astro'",
     "typecheck": "astro check",
+    "test": "node --test",
     "lint": "eslint --config .config/eslint.config.js .",
     "format:check": "prettier --check --ignore-unknown '!yarn.lock' '!**/*.md' .",
     "format:fix": "prettier --write --ignore-unknown '!yarn.lock' '!**/*.md' .",

--- a/src/client/analysis/registry.ts
+++ b/src/client/analysis/registry.ts
@@ -25,6 +25,7 @@ import redirects from './rules/redirects';
 import serverInfo from './rules/server-info';
 import robotsTxt from './rules/robots-txt';
 import tlsClientCompat from './rules/tls-client-compat';
+import breachHistory from './rules/breach-history';
 
 /* Map of card id to its pure analyzer */
 export const analyzers: Record<string, Analyzer> = {
@@ -51,6 +52,7 @@ export const analyzers: Record<string, Analyzer> = {
   'server-info': serverInfo,
   'robots-txt': robotsTxt,
   'tls-client-compat': tlsClientCompat,
+  'breach-history': breachHistory,
 };
 
 /* Run each analyzer against successful job state with valid object payload */

--- a/src/client/analysis/rules/breach-history.ts
+++ b/src/client/analysis/rules/breach-history.ts
@@ -1,0 +1,59 @@
+import type { Analyzer } from '../types';
+
+const MAX_LISTED = 4;
+
+// A catalogued breach is history, not a live misconfiguration, so it is never
+// reported as critical alongside something an attacker can exploit right now.
+// It is still worth surfacing: it says credentials for this service have
+// already circulated.
+const breachHistory: Analyzer = (d) => {
+  const breaches: any[] = Array.isArray(d?.breaches) ? d.breaches : [];
+  if (!breaches.length) {
+    return d?.domain ? [{ severity: 'pass', title: 'No known data breaches on record' }] : [];
+  }
+
+  const named = (list: any[]) => {
+    const names = list
+      .slice(0, MAX_LISTED)
+      .map((b) => b.title || b.name)
+      .join(', ');
+    return list.length > MAX_LISTED ? `${names} (+${list.length - MAX_LISTED} more)` : names;
+  };
+
+  const confirmed = breaches.filter((b) => b.trustworthy);
+  const unconfirmed = breaches.filter((b) => !b.trustworthy);
+  const leakedCredentials = confirmed.filter((b) => b.severity === 'critical');
+  const otherConfirmed = confirmed.filter((b) => b.severity !== 'critical');
+
+  const findings = [];
+
+  if (leakedCredentials.length) {
+    findings.push({
+      severity: 'issue' as const,
+      title: `Credentials exposed in ${leakedCredentials.length} past breach(es) of this service`,
+      detail:
+        `${named(leakedCredentials)}. Assume affected passwords are public: enforce a reset, ` +
+        'and rate-limit or monitor logins for credential stuffing',
+    });
+  }
+
+  if (otherConfirmed.length) {
+    findings.push({
+      severity: 'warning' as const,
+      title: `${otherConfirmed.length} past data breach(es) recorded for this service`,
+      detail: `${named(otherConfirmed)}. User data was exposed, but no credentials were included`,
+    });
+  }
+
+  if (unconfirmed.length) {
+    findings.push({
+      severity: 'info' as const,
+      title: `${unconfirmed.length} unconfirmed breach(es) listed against this domain`,
+      detail: `${named(unconfirmed)}. Unverified, fabricated or spam-list entries — treat with care`,
+    });
+  }
+
+  return findings;
+};
+
+export default breachHistory;

--- a/src/client/components/Results/BreachHistory.tsx
+++ b/src/client/components/Results/BreachHistory.tsx
@@ -1,0 +1,240 @@
+import styled from '@emotion/styled';
+import colors from 'client/styles/colors';
+import { Card } from 'client/components/Form/Card';
+import Row from 'client/components/Form/Row';
+
+type Tier = 'critical' | 'high' | 'medium' | 'low';
+
+interface DataClass {
+  name: string;
+  tier: Tier;
+}
+
+interface Breach {
+  name: string;
+  title: string;
+  domain: string | null;
+  breachDate: string | null;
+  accounts: number | null;
+  description: string;
+  logo: string | null;
+  dataClasses: DataClass[];
+  severity: Tier;
+  verified: boolean;
+  fabricated: boolean;
+  spamList: boolean;
+  sensitive: boolean;
+  retired: boolean;
+  malware: boolean;
+  stealerLog: boolean;
+  trustworthy: boolean;
+}
+
+interface BreachHistory {
+  domain: string;
+  breaches: Breach[];
+  summary: {
+    total: number;
+    totalAccounts: number;
+    worstSeverity: Tier | null;
+    latestBreachDate: string | null;
+    verifiedCount: number;
+    unverifiedCount: number;
+  };
+  source?: { name: string; url: string; license: string; licenseUrl: string };
+}
+
+const tierColors: Record<Tier, string> = {
+  critical: colors.danger,
+  high: colors.error,
+  medium: colors.warning,
+  low: colors.info,
+};
+
+const cardStyles = `
+  max-height: 60rem;
+`;
+
+const AllClear = styled.p`
+  color: ${colors.success};
+  margin: 0.5rem 0;
+`;
+
+const BreachList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0 0;
+`;
+
+const BreachItem = styled.li<{ tier: Tier }>`
+  border-left: 3px solid ${(props) => tierColors[props.tier]};
+  background: ${colors.primaryTransparent};
+  border-radius: 0 4px 4px 0;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+`;
+
+const BreachHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  img {
+    width: 1.5rem;
+    height: 1.5rem;
+    object-fit: contain;
+    border-radius: 2px;
+  }
+  b {
+    flex: 1;
+  }
+`;
+
+const Badge = styled.span<{ tone: string }>`
+  background: ${(props) => props.tone};
+  color: ${colors.backgroundDarker};
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  white-space: nowrap;
+`;
+
+const ExposedData = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0.35rem 0 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  li {
+    background: ${colors.background};
+    border-radius: 4px;
+    padding: 0.05rem 0.4rem;
+    font-size: 0.8rem;
+  }
+  li:before {
+    content: '●';
+    margin-right: 0.3rem;
+  }
+`;
+
+const Caveat = styled.p`
+  color: ${colors.warning};
+  font-size: 0.8rem;
+  margin: 0.35rem 0 0 0;
+`;
+
+const Description = styled.p`
+  color: ${colors.textColorSecondary};
+  font-size: 0.8rem;
+  margin: 0.35rem 0 0 0;
+`;
+
+const Attribution = styled.small`
+  display: block;
+  margin-top: 0.5rem;
+  color: ${colors.textColorSecondary};
+  a {
+    color: ${colors.primary};
+  }
+`;
+
+// 152445165 -> "152.4M", so a headline number stays readable
+const formatAccounts = (value: number | null): string => {
+  if (value === null || !Number.isFinite(value)) return 'Unknown';
+  if (value >= 1e9) return `${(value / 1e9).toFixed(1)}B`;
+  if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M`;
+  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
+  return value.toString();
+};
+
+// Everything that qualifies how much weight a reader should give an entry
+const caveatsFor = (breach: Breach): string[] => {
+  const caveats: string[] = [];
+  if (breach.fabricated) caveats.push('flagged by HIBP as likely fabricated');
+  if (!breach.verified && !breach.fabricated) caveats.push('unverified by HIBP');
+  if (breach.spamList) caveats.push('a spam list rather than a service breach');
+  if (breach.stealerLog) caveats.push('sourced from stealer malware logs');
+  if (breach.malware) caveats.push('malware-sourced');
+  if (breach.retired) caveats.push('retired from the HIBP index');
+  return caveats;
+};
+
+const BreachRow = (props: { breach: Breach }): JSX.Element => {
+  const { breach } = props;
+  const caveats = caveatsFor(breach);
+  return (
+    <BreachItem tier={breach.severity}>
+      <BreachHeader>
+        {breach.logo && <img src={breach.logo} alt="" loading="lazy" />}
+        <b>{breach.title}</b>
+        {breach.trustworthy ? (
+          <Badge tone={colors.success}>✓ Verified</Badge>
+        ) : (
+          <Badge tone={colors.warning}>Unconfirmed</Badge>
+        )}
+      </BreachHeader>
+      {breach.breachDate && <Row lbl="Breached" val={breach.breachDate} />}
+      <Row lbl="Accounts affected" val={formatAccounts(breach.accounts)} />
+      {breach.dataClasses.length > 0 && (
+        <>
+          <Row lbl="" val="">
+            <span className="lbl">Exposed data</span>
+          </Row>
+          <ExposedData>
+            {breach.dataClasses.map((cls) => (
+              <li key={cls.name} style={{ color: tierColors[cls.tier] }} title={`${cls.tier} risk`}>
+                <span style={{ color: colors.textColor }}>{cls.name}</span>
+              </li>
+            ))}
+          </ExposedData>
+        </>
+      )}
+      {caveats.length > 0 && <Caveat>⚠️ Treat with care — {caveats.join(', ')}</Caveat>}
+      {breach.description && <Description>{breach.description}</Description>}
+    </BreachItem>
+  );
+};
+
+const BreachHistoryCard = (props: {
+  data: BreachHistory;
+  title: string;
+  actionButtons: any;
+}): JSX.Element => {
+  const { breaches = [], summary, domain, source } = props.data || ({} as BreachHistory);
+
+  return (
+    <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
+      {breaches.length === 0 ? (
+        <AllClear>✅ No known breaches for {domain || 'this domain'}</AllClear>
+      ) : (
+        <>
+          <Row lbl="Known breaches" val={summary.total.toString()} />
+          <Row lbl="Accounts affected" val={formatAccounts(summary.totalAccounts)} />
+          {summary.latestBreachDate && <Row lbl="Most recent" val={summary.latestBreachDate} />}
+          <BreachList>
+            {breaches.map((breach) => (
+              <BreachRow key={breach.name} breach={breach} />
+            ))}
+          </BreachList>
+        </>
+      )}
+      {source && (
+        <Attribution>
+          Source:{' '}
+          <a href={source.url} target="_blank" rel="noreferrer">
+            {source.name}
+          </a>
+          , licensed under{' '}
+          <a href={source.licenseUrl} target="_blank" rel="noreferrer">
+            {source.license}
+          </a>
+        </Attribution>
+      )}
+    </Card>
+  );
+};
+
+export default BreachHistoryCard;

--- a/src/client/components/Results/BreachHistory.tsx
+++ b/src/client/components/Results/BreachHistory.tsx
@@ -32,6 +32,8 @@ interface Breach {
 
 interface BreachHistory {
   domain: string;
+  redirectedTo?: string | null;
+  domainsChecked?: string[];
   breaches: Breach[];
   summary: {
     total: number;
@@ -126,6 +128,18 @@ const Caveat = styled.p`
   margin: 0.35rem 0 0 0;
 `;
 
+const RedirectNote = styled.p`
+  color: ${colors.info};
+  font-size: 0.8rem;
+  margin: 0.5rem 0 0 0;
+`;
+
+const RecordedAgainst = styled.p`
+  color: ${colors.textColorSecondary};
+  font-size: 0.75rem;
+  margin: 0.35rem 0 0 0;
+`;
+
 const Description = styled.p`
   color: ${colors.textColorSecondary};
   font-size: 0.8rem;
@@ -162,9 +176,12 @@ const caveatsFor = (breach: Breach): string[] => {
   return caveats;
 };
 
-const BreachRow = (props: { breach: Breach }): JSX.Element => {
-  const { breach } = props;
+const BreachRow = (props: { breach: Breach; scannedDomain: string }): JSX.Element => {
+  const { breach, scannedDomain } = props;
   const caveats = caveatsFor(breach);
+  // Only ever attributed to the domain HIBP recorded it against, so a redirect
+  // never quietly transfers someone else's breach onto the scanned domain
+  const otherDomain = breach.domain && breach.domain !== scannedDomain ? breach.domain : null;
   return (
     <BreachItem tier={breach.severity}>
       <BreachHeader>
@@ -192,6 +209,7 @@ const BreachRow = (props: { breach: Breach }): JSX.Element => {
           </ExposedData>
         </>
       )}
+      {otherDomain && <RecordedAgainst>Recorded against {otherDomain}</RecordedAgainst>}
       {caveats.length > 0 && <Caveat>⚠️ Treat with care — {caveats.join(', ')}</Caveat>}
       {breach.description && <Description>{breach.description}</Description>}
     </BreachItem>
@@ -203,12 +221,25 @@ const BreachHistoryCard = (props: {
   title: string;
   actionButtons: any;
 }): JSX.Element => {
-  const { breaches = [], summary, domain, source } = props.data || ({} as BreachHistory);
+  const {
+    breaches = [],
+    summary,
+    domain,
+    redirectedTo,
+    domainsChecked,
+    source,
+  } = props.data || ({} as BreachHistory);
+  const checked = domainsChecked?.length ? domainsChecked.join(' and ') : domain || 'this domain';
 
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
+      {redirectedTo && (
+        <RedirectNote>
+          ℹ️ {domain} redirects to {redirectedTo}, so both were checked
+        </RedirectNote>
+      )}
       {breaches.length === 0 ? (
-        <AllClear>✅ No known breaches for {domain || 'this domain'}</AllClear>
+        <AllClear>✅ No known breaches for {checked}</AllClear>
       ) : (
         <>
           <Row lbl="Known breaches" val={summary.total.toString()} />
@@ -216,7 +247,7 @@ const BreachHistoryCard = (props: {
           {summary.latestBreachDate && <Row lbl="Most recent" val={summary.latestBreachDate} />}
           <BreachList>
             {breaches.map((breach) => (
-              <BreachRow key={breach.name} breach={breach} />
+              <BreachRow key={breach.name} breach={breach} scannedDomain={domain} />
             ))}
           </BreachList>
         </>

--- a/src/client/components/misc/DocContent.tsx
+++ b/src/client/components/misc/DocContent.tsx
@@ -61,14 +61,16 @@ const DocContent = (id: string) => {
           ),
         )}
       </ul>
-      <details>
-        <summary>
-          <Heading as="h4" size="small">
-            Example
-          </Heading>
-        </summary>
-        <img width="300" src={doc.screenshot} alt="Screenshot" />
-      </details>
+      {doc.screenshot && (
+        <details>
+          <summary>
+            <Heading as="h4" size="small">
+              Example
+            </Heading>
+          </summary>
+          <img width="300" src={doc.screenshot} alt="Screenshot" />
+        </details>
+      )}
     </JobDocsContainer>
   ) : (
     <JobDocsContainer>

--- a/src/client/jobs/registry.ts
+++ b/src/client/jobs/registry.ts
@@ -39,6 +39,7 @@ import TlsConnectionCard from 'client/components/Results/TlsConnection';
 import TlsSecurityAuditCard from 'client/components/Results/TlsSecurityAudit';
 import TlsClientCompatCard from 'client/components/Results/TlsClientCompat';
 import SubdomainsCard from 'client/components/Results/Subdomains';
+import BreachHistoryCard from 'client/components/Results/BreachHistory';
 
 import type { JobSpec, JobContext, JobsState } from './types';
 
@@ -262,6 +263,12 @@ export const jobs: JobSpec[] = [
     expectedAddressTypes: [...URL_ONLY],
     cards: [card('threats', 'Threats', ['security'], ThreatsCard)],
     fetcher: fetchAndProcess('threats?url=${url}'),
+  },
+  {
+    id: 'breach-history',
+    expectedAddressTypes: [...URL_ONLY],
+    cards: [card('breach-history', 'Data Breach History', ['security', 'meta'], BreachHistoryCard)],
+    fetcher: fetchAndProcess('breach-history?url=${url}'),
   },
   {
     id: 'mail-config',

--- a/src/client/utils/docs.ts
+++ b/src/client/utils/docs.ts
@@ -609,6 +609,21 @@ const docs: Doc[] = [
     screenshot: 'https://pixelflare.cc/alicia/web-check/wc-threats',
   },
   {
+    id: 'breach-history',
+    title: 'Data Breach History',
+    description:
+      "Checks whether the organisation behind the target domain has itself appeared in a catalogued data breach, using the public Have I Been Pwned breach catalogue. For each incident it shows the date, how many accounts were affected, and which classes of data were exposed, ranked by how damaging they are — credentials and financial records first, plain identifiers last. Only the registrable domain is ever sent upstream: no email address, account or password is submitted, and this makes no claim about any individual user's data.",
+    use: "A breach in a service's own history tells you something no live scan can: that credentials belonging to this site have already circulated, and roughly when. That matters when judging whether password reuse, credential stuffing or account takeover is a live risk for its users, and it is useful background when assessing a vendor. Bear in mind entries are catalogued per organisation, so a clean result means only that no breach has been catalogued against this domain, not that none occurred. HIBP also flags some entries as unverified, fabricated, or sourced from spam lists and stealer malware, and those are marked as unconfirmed here rather than presented as fact.",
+    resources: [
+      { title: 'Have I Been Pwned', link: 'https://haveibeenpwned.com' },
+      { title: 'HIBP API docs', link: 'https://haveibeenpwned.com/API/v3' },
+      {
+        title: 'Credential stuffing (OWASP)',
+        link: 'https://owasp.org/www-community/attacks/Credential_stuffing',
+      },
+    ],
+  },
+  {
     id: 'tls-connection',
     title: 'TLS Connection',
     description:


### PR DESCRIPTION
## What this does

Web Check tells you how a site is configured *today*. It says nothing about whether the service behind it has already lost its users' data — which is often the more useful thing to know when you are judging a vendor, or working out whether credential stuffing is a live risk for a login page.

This adds a **Data Breach History** check against the public [Have I Been Pwned](https://haveibeenpwned.com) breach catalogue: which incidents are on record for the domain, when, how many accounts, and which classes of data were exposed.

**No API key.** The `/api/v3/breaches?domain=` endpoint is unauthenticated, so this works on every self-hosted instance out of the box, with nothing to configure.

## Privacy — deliberately the domain-level catalogue only

HIBP exposes three easily-confused things. This uses only the first:

| | Used here | Why |
| --- | --- | --- |
| `/breaches?domain=` — the breach catalogue | ✅ | Public, key-less, domain only |
| `/breachedaccount/{email}` | ❌ | Needs a paid key, and means sending someone's address to a third party |
| HIBP "domain search" | ❌ | Needs proof of domain ownership |

Only the registrable domain leaves the server. No email address, account or password is submitted, and the check makes no claim about any individual user's data.

## Three things the raw feed does not give you for free

**1. Subdomains silently miss.** HIBP indexes against the registrable domain, so `store.adobe.com` returns `[]` while `adobe.com` returns the breach. The hostname is folded down with `psl`, the same way `whois.js` and `subdomains.js` already do it.

**2. Descriptions contain real markup**, including anchors with `target="_blank"`:

```
...password and a password hint in plain text. The unencrypted hints also
<a href="http://www.troyhunt.com/..." target="_blank" rel="noopener">disclosed
much about the passwords</a> adding further to the risk...
```

Rendering third-party HTML is the exact flaw this tool reports on other people's sites, so tags are stripped server-side rather than trusted downstream.

**3. The catalogue is not all equally credible.** Of the 1026 entries currently published, 42 are unverified, 3 fabricated, 16 spam lists and 6 stealer logs. Those are kept — hiding them would be its own distortion — but flagged, so a fabricated entry is never shown with the weight of a confirmed one.

Exposed data classes are tiered by how damaging they are (credentials and financial records, then data enabling targeted attacks, then plain identifiers), which drives both the ordering and the colour coding.

## Example

`linkedin.com`, through the live endpoint:

```
domain=linkedin.com  breaches=3  accounts=310,098,844  worst=critical  latest=2023-11-04
  - LinkedIn                             2012-05-05  critical  trust=true
      Passwords[critical] Email addresses[medium]
  - LinkedIn Scraped Data (2021)         2021-04-08  medium    trust=true
      Email addresses[medium] Geographic locations[medium] Names[medium] ...
  - LinkedIn Scraped and Faked Data (2023) 2023-11-04 medium   trust=false
      Email addresses[medium] Geographic locations[medium] Names[medium] ...
```

The faked 2023 entry sorts last and is badged "unconfirmed" rather than presented as a breach.

## Advisory integration

A catalogued breach is history, not a live misconfiguration, so it is **deliberately never reported as critical** — putting a 2012 breach beside "MySQL exposed to the internet" would misrepresent what actually needs attention today. Instead:

- credentials exposed in a confirmed breach → **issue**, with advice to force a reset and watch for credential stuffing
- other confirmed breaches → **warning**
- unverified / fabricated / spam-list entries → **info**
- nothing on record → **pass**

## Tests

28 unit tests using the **built-in Node test runner** — no new dependencies, no config file. They cover domain folding (including multi-part suffixes like `.co.uk`), HTML stripping and entity decoding, data-class tiering, sorting, the trust flags, and the malformed-input paths.

```
yarn test   # node --test
ℹ tests 28
ℹ pass 28
ℹ fail 0
```

A `🧪 Unit Tests` job is wired into `.github/workflows/ci.yml` alongside the existing lint and typecheck jobs.

## Verification

- `yarn test` — 28/28
- `yarn lint` — clean
- `yarn typecheck` (`astro check`) — 0 errors, 0 warnings, 0 hints
- `yarn build` — completes
- `prettier --check` on every touched file — clean
- Live end-to-end runs through the real route and middleware: `adobe.com`, `store.adobe.com` (proving the subdomain fold), a full `https://www.linkedin.com/feed` URL, a clean domain, and an IP (correctly skipped)
- Card and Advisory rule both exercised against live HIBP responses

## Notes

- **Most domains return nothing**, which is the expected result. The card reports that explicitly rather than hiding, matching how the vulnerabilities card reports a clean host.
- HIBP publishes under CC BY 4.0, so attribution and the licence link ship with the response rather than being hardcoded in the component.
- A clean result means only that no breach has been *catalogued* against the domain — not that none occurred. That caveat is stated in the in-app docs and the README.
- **Small overlap with #333**: both add the same one-line `test` script to `package.json` and the same CI job. Whichever lands first, the other reduces to a trivial conflict. Everything else here is new files or additive registry entries.
