### PR TITLE
Add Simplified Chinese localization and language switching

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import express from 'express';
@@ -29,7 +30,7 @@ if (trustProxy) {
   app.set('trust proxy', parsed);
 }
 
-const __filename = new URL(import.meta.url).pathname;
+const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const port = process.env.PORT || 3000; // The port to run the server on
@@ -100,7 +101,7 @@ apiFiles.forEach(async (dirent) => {
   const routeName = dirent.name.split('.')[0];
   const route = `${API_DIR}/${routeName}`;
 
-  const handlerModule = await import(path.join(dirPath, dirent.name));
+  const handlerModule = await import(pathToFileURL(path.join(dirPath, dirent.name)).href);
   const handler = handlerModule.default || handlerModule;
   handlers[route] = handler;
 
@@ -210,7 +211,7 @@ if (process.env.DISABLE_GUI && process.env.DISABLE_GUI !== 'false') {
   app.use(express.static('dist/client/'));
   app.use(async (req, res, next) => {
     const ssrHandlerPath = path.join(__dirname, 'dist', 'server', 'entry.mjs');
-    import(ssrHandlerPath)
+    import(pathToFileURL(ssrHandlerPath).href)
       .then(({ handler: ssrHandler }) => {
         ssrHandler(req, res, next);
       })

--- a/src/client/components/Form/Nav.tsx
+++ b/src/client/components/Form/Nav.tsx
@@ -4,6 +4,8 @@ import type { ReactNode } from 'react';
 import { StyledCard } from 'client/components/Form/Card';
 import Heading from 'client/components/Form/Heading';
 import colors from 'client/styles/colors';
+import LanguageSwitcher from 'client/components/misc/LanguageSwitcher';
+import { useLanguage } from 'client/i18n';
 
 const Header = styled(StyledCard)`
   margin: 0 auto;
@@ -16,16 +18,36 @@ const Header = styled(StyledCard)`
   width: 95vw;
 `;
 
+const HeaderActions = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  min-width: 0;
+  @media (max-width: 600px) {
+    width: 100%;
+    justify-content: space-between;
+  }
+`;
+
 const Nav = (props: { children?: ReactNode }) => {
+  const { language } = useLanguage();
   return (
     <Header as="header">
       <Heading color={colors.primary} size="large">
-        <img width="64" src="/favicon.svg" alt="Web Check Icon" />
+        <img
+          width="64"
+          src="/favicon.svg"
+          alt={language === 'zh-CN' ? 'Web Check 图标' : 'Web Check icon'}
+        />
         <a href="/" target="_self">
           Web Check
         </a>
       </Heading>
-      {props.children && props.children}
+      <HeaderActions>
+        {props.children && props.children}
+        <LanguageSwitcher />
+      </HeaderActions>
     </Header>
   );
 };

--- a/src/client/components/Form/Row.tsx
+++ b/src/client/components/Form/Row.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import colors from 'client/styles/colors';
 import Heading from 'client/components/Form/Heading';
+import { localizeText, useLanguage, type Language } from 'client/i18n';
 
 export interface RowProps {
   lbl: string;
@@ -107,18 +108,18 @@ const isDateLike = (value: any): boolean => {
   return date >= new Date('1995-01-01') && date <= new Date('2030-12-31');
 };
 
-const formatDate = (dateString: string): string => {
-  return new Intl.DateTimeFormat('en-GB', {
+const formatDate = (dateString: string, language: Language): string => {
+  return new Intl.DateTimeFormat(language === 'zh-CN' ? 'zh-CN' : 'en-GB', {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
   }).format(new Date(dateString));
 };
 
-const formatValue = (value: any): string => {
-  if (isDateLike(value)) return formatDate(value);
+const formatValue = (value: any, language: Language): string => {
+  if (isDateLike(value)) return formatDate(value, language);
   if (typeof value === 'boolean') return value ? '✅' : '❌';
-  return value;
+  return localizeText(value, language);
 };
 
 const copyToClipboard = (text: string) => {
@@ -131,15 +132,16 @@ const snip = (text: string, length: number = 80) => {
 };
 
 export const ExpandableRow = (props: RowProps) => {
+  const { language } = useLanguage();
   const { lbl, val, title, rowList, open } = props;
   return (
     <Details open={open}>
       <StyledRow as="summary" key={`${lbl}-${val}`}>
         <span className="lbl" title={title?.toString()}>
-          {lbl}
+          {localizeText(lbl, language)}
         </span>
         <span className="val" title={val?.toString()}>
-          {val.toString()}
+          {localizeText(val, language)}
         </span>
       </StyledRow>
       {rowList && (
@@ -148,14 +150,14 @@ export const ExpandableRow = (props: RowProps) => {
             return (
               <StyledRow as="li" key={`${row.lbl}-${index}`}>
                 <span className="lbl" title={row.title?.toString()}>
-                  {row.lbl}
+                  {localizeText(row.lbl, language)}
                 </span>
                 <span
                   className="val"
                   title={row.val?.toString()}
                   onClick={() => copyToClipboard(row.val)}
                 >
-                  {formatValue(row.val)}
+                  {formatValue(row.val, language)}
                 </span>
                 {row.plaintext && <PlainText>{row.plaintext}</PlainText>}
                 {row.listResults && (
@@ -175,11 +177,12 @@ export const ExpandableRow = (props: RowProps) => {
 };
 
 export const ListRow = (props: { list: string[]; title: string }) => {
+  const { language } = useLanguage();
   const { list, title } = props;
   return (
     <>
       <Heading as="h4" size="small" align="left" color={colors.primary}>
-        {title}
+        {localizeText(title, language)}
       </Heading>
       {list.map((entry: string, index: number) => {
         return (
@@ -193,17 +196,18 @@ export const ListRow = (props: { list: string[]; title: string }) => {
 };
 
 const Row = (props: RowProps) => {
+  const { language } = useLanguage();
   const { lbl, val, title, plaintext, listResults, children } = props;
   if (children) return <StyledRow key={`${lbl}-${val}`}>{children}</StyledRow>;
   return (
     <StyledRow key={`${lbl}-${val}`}>
       {lbl && (
         <span className="lbl" title={title?.toString()}>
-          {lbl}
+          {localizeText(lbl, language)}
         </span>
       )}
       <span className="val" title={val?.toString()} onClick={() => copyToClipboard(val)}>
-        {formatValue(val)}
+        {formatValue(val, language)}
       </span>
       {plaintext && <PlainText>{plaintext}</PlainText>}
       {listResults && (

--- a/src/client/components/Results/CarbonFootprint.tsx
+++ b/src/client/components/Results/CarbonFootprint.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { Card } from 'client/components/Form/Card';
 import Row from 'client/components/Form/Row';
 import colors from 'client/styles/colors';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const LearnMoreInfo = styled.p`
   font-size: 0.8rem;
@@ -31,12 +32,15 @@ const formatKwh = (kwh: number): string => {
 };
 
 const CarbonCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   const carbons = props.data.statistics;
   const cleanerThan = props.data.cleanerThan;
 
   return (
     <Card heading={props.title} actionButtons={props.actionButtons}>
-      {!carbons?.adjustedBytes && <p>Unable to calculate carbon footprint for host</p>}
+      {!carbons?.adjustedBytes && (
+        <p>{localizeText('Unable to calculate carbon footprint for host', language)}</p>
+      )}
       {carbons?.adjustedBytes > 0 && (
         <>
           {props.data.bytes > 0 && (
@@ -52,7 +56,7 @@ const CarbonCard = (props: { data: any; title: string; actionButtons: any }): JS
       )}
       <br />
       <LearnMoreInfo>
-        Calculated using the{' '}
+        {language === 'zh-CN' ? '根据以下模型计算：' : 'Calculated using the '}
         <a
           href="https://sustainablewebdesign.org/estimating-digital-emissions"
           target="_blank"

--- a/src/client/components/Results/DomainLookup.tsx
+++ b/src/client/components/Results/DomainLookup.tsx
@@ -1,6 +1,7 @@
 import colors from 'client/styles/colors';
 import { Card } from 'client/components/Form/Card';
 import Row from 'client/components/Form/Row';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const cardStyles = `
 span.val {
@@ -10,6 +11,7 @@ span.val {
 `;
 
 const DomainLookupCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   const d = props.data || {};
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
@@ -21,7 +23,7 @@ const DomainLookupCard = (props: { data: any; title: string; actionButtons: any 
       {d.registrarWhoisServer && <Row lbl="Registrar WHOIS Server" val={d.registrarWhoisServer} />}
       {d.registrar && (
         <Row lbl="" val="">
-          <span className="lbl">Registrar</span>
+          <span className="lbl">{localizeText('Registrar', language)}</span>
           <span className="val">
             <a href={d.registrarUrl || '#'}>{d.registrar}</a>
           </span>

--- a/src/client/components/Results/Firewall.tsx
+++ b/src/client/components/Results/Firewall.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { Card } from 'client/components/Form/Card';
 import Row from 'client/components/Form/Row';
+import { useLanguage } from 'client/i18n';
 
 const Note = styled.small`
   opacity: 0.5;
@@ -9,6 +10,7 @@ const Note = styled.small`
 `;
 
 const FirewallCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   const data = props.data;
   return (
     <Card heading={props.title} actionButtons={props.actionButtons}>
@@ -16,8 +18,9 @@ const FirewallCard = (props: { data: any; title: string; actionButtons: any }): 
       {data.waf && <Row lbl="WAF" val={data.waf} />}
       {!data.hasWaf && (
         <Note>
-          *The domain may be protected with a proprietary or custom WAF which we were unable to
-          identify automatically
+          {language === 'zh-CN'
+            ? '*该域名可能使用专有或自定义 WAF，当前检查无法自动识别。'
+            : '*The domain may be protected with a proprietary or custom WAF which we were unable to identify automatically'}
         </Note>
       )}
     </Card>

--- a/src/client/components/Results/OpenPorts.tsx
+++ b/src/client/components/Results/OpenPorts.tsx
@@ -1,11 +1,13 @@
 import { Card } from 'client/components/Form/Card';
 import Row from 'client/components/Form/Row';
+import { useLanguage } from 'client/i18n';
 
 const cardStyles = `
   small { margin-top: 1rem; opacity: 0.5; }
 `;
 
 const OpenPortsCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   const portData = props.data;
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
@@ -16,7 +18,7 @@ const OpenPortsCard = (props: { data: any; title: string; actionButtons: any }):
       ))}
       <br />
       <small>
-        Unable to establish connections to:
+        {language === 'zh-CN' ? '无法建立连接的端口：' : 'Unable to establish connections to:'}
         <br />
         {portData.failedPorts.join(', ')}
       </small>

--- a/src/client/components/Results/Redirects.tsx
+++ b/src/client/components/Results/Redirects.tsx
@@ -1,6 +1,7 @@
 import colors from 'client/styles/colors';
 import { Card } from 'client/components/Form/Card';
 import Row from 'client/components/Form/Row';
+import { useLanguage } from 'client/i18n';
 
 const cardStyles = `
   div {
@@ -20,6 +21,7 @@ const cardStyles = `
 `;
 
 const RedirectsCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   // The API chain includes the original URL as its first entry
   const chain = props.data?.redirects || [];
   const count = Math.max(chain.length - 1, 0);
@@ -29,7 +31,9 @@ const RedirectsCard = (props: { data: any; title: string; actionButtons: any }):
       {count > 0 && (
         <>
           <p className="redirect-count">
-            Followed {count} redirect{count === 1 ? '' : 's'} when contacting host
+            {language === 'zh-CN'
+              ? `访问目标时经历了 ${count} 次重定向`
+              : `Followed ${count} redirect${count === 1 ? '' : 's'} when contacting host`}
           </p>
           {chain.slice(1).map((redirect: any, index: number) => (
             <Row lbl="" val="" key={index}>

--- a/src/client/components/Results/RobotsTxt.tsx
+++ b/src/client/components/Results/RobotsTxt.tsx
@@ -1,5 +1,6 @@
 import { Card } from 'client/components/Form/Card';
 import Row, { type RowProps } from 'client/components/Form/Row';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const cardStyles = `
   grid-row: span 2;
@@ -14,13 +15,14 @@ const RobotsTxtCard = (props: {
   title: string;
   actionButtons: any;
 }): JSX.Element => {
+  const { language } = useLanguage();
   const { data } = props;
   const robots = data?.robots || [];
 
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
       <div className="content">
-        {robots.length === 0 && <p>No crawl rules found.</p>}
+        {robots.length === 0 && <p>{localizeText('No crawl rules found.', language)}</p>}
         {robots.map((row: RowProps, index: number) => {
           return <Row key={`${row.lbl}-${index}`} lbl={row.lbl} val={row.val} />;
         })}

--- a/src/client/components/Results/Screenshot.tsx
+++ b/src/client/components/Results/Screenshot.tsx
@@ -1,4 +1,5 @@
 import { Card } from 'client/components/Form/Card';
+import { useLanguage } from 'client/i18n';
 
 const cardStyles = `
   overflow: auto;
@@ -17,14 +18,12 @@ const ScreenshotCard = (props: {
   actionButtons: any;
 }): JSX.Element => {
   const screenshot = props.data;
+  const { language } = useLanguage();
+  const alt = language === 'zh-CN' ? '完整页面截图' : 'Full-page screenshot';
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
-      {screenshot.image && (
-        <img src={`data:image/png;base64,${screenshot.image}`} alt="Full page screenshot" />
-      )}
-      {!screenshot.image && screenshot.data && (
-        <img src={screenshot.data} alt="Full page screenshot" />
-      )}
+      {screenshot.image && <img src={`data:image/png;base64,${screenshot.image}`} alt={alt} />}
+      {!screenshot.image && screenshot.data && <img src={screenshot.data} alt={alt} />}
     </Card>
   );
 };

--- a/src/client/components/Results/SecurityTxt.tsx
+++ b/src/client/components/Results/SecurityTxt.tsx
@@ -1,6 +1,7 @@
 import { Card } from 'client/components/Form/Card';
 import Row, { Details } from 'client/components/Form/Row';
 import colors from 'client/styles/colors';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const cardStyles = `
 small {
@@ -31,6 +32,7 @@ const getPagePath = (url: string): string => {
 };
 
 const SecurityTxtCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   const securityTxt = props.data;
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
@@ -57,15 +59,16 @@ const SecurityTxtCard = (props: { data: any; title: string; actionButtons: any }
               );
             })}
           <Details>
-            <summary>View Full Policy</summary>
+            <summary>{localizeText('View Full Policy', language)}</summary>
             <pre>{securityTxt.content}</pre>
           </Details>
         </>
       )}
       {!securityTxt.isPresent && (
         <small>
-          Having a security.txt ensures security researchers know how and where to safely report
-          vulnerabilities.
+          {language === 'zh-CN'
+            ? '发布 security.txt 可以让安全研究人员知道如何通过正确渠道报告漏洞。'
+            : 'Having a security.txt ensures security researchers know how and where to safely report vulnerabilities.'}
         </small>
       )}
     </Card>

--- a/src/client/components/Results/ServerLocation.tsx
+++ b/src/client/components/Results/ServerLocation.tsx
@@ -5,6 +5,7 @@ import LocationMap from 'client/components/misc/LocationMap';
 import Flag from 'client/components/misc/Flag';
 import { TextSizes } from 'client/styles/typography';
 import Row, { StyledRow } from 'client/components/Form/Row';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const cardStyles = '';
 
@@ -30,6 +31,7 @@ const ServerLocationCard = (props: {
   title: string;
   actionButtons: any;
 }): JSX.Element => {
+  const { language } = useLanguage();
   const location = props.data;
   const {
     city,
@@ -52,7 +54,7 @@ const ServerLocationCard = (props: {
       )}
       {country && (
         <Row lbl="" val="">
-          <b>Country</b>
+          <b>{localizeText('Country', language)}</b>
           <CountryValue>
             {country}
             {countryCode && <Flag countryCode={countryCode} width={28} />}
@@ -67,7 +69,8 @@ const ServerLocationCard = (props: {
       <MapRow>
         <LocationMap lat={coords.latitude} lon={coords.longitude} label={`Server (${isp})`} />
         <SmallText>
-          Latitude: {coords.latitude}, Longitude: {coords.longitude}{' '}
+          {language === 'zh-CN' ? '纬度' : 'Latitude'}: {coords.latitude},{' '}
+          {language === 'zh-CN' ? '经度' : 'Longitude'}: {coords.longitude}{' '}
         </SmallText>
       </MapRow>
     </Card>

--- a/src/client/components/Results/ServerStatus.tsx
+++ b/src/client/components/Results/ServerStatus.tsx
@@ -1,6 +1,7 @@
 import colors from 'client/styles/colors';
 import { Card } from 'client/components/Form/Card';
 import Row from 'client/components/Form/Row';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const cardStyles = `
 span.val {
@@ -10,15 +11,16 @@ span.val {
 `;
 
 const ServerStatusCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   const serverStatus = props.data;
   return (
     <Card heading={props.title.toString()} actionButtons={props.actionButtons} styles={cardStyles}>
       <Row lbl="" val="">
-        <span className="lbl">Is Up?</span>
+        <span className="lbl">{localizeText('Is Up?', language)}</span>
         {serverStatus.isUp ? (
-          <span className="val up">✅ Online</span>
+          <span className="val up">✅ {localizeText('Online', language)}</span>
         ) : (
-          <span className="val down">❌ Offline</span>
+          <span className="val down">❌ {localizeText('Offline', language)}</span>
         )}
       </Row>
       <Row lbl="Status Code" val={serverStatus.responseCode} />

--- a/src/client/components/Results/Sitemap.tsx
+++ b/src/client/components/Results/Sitemap.tsx
@@ -1,6 +1,7 @@
 import { Card } from 'client/components/Form/Card';
 import Row, { ExpandableRow } from 'client/components/Form/Row';
 import colors from 'client/styles/colors';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const cardStyles = `
   max-height: 50rem;
@@ -17,6 +18,7 @@ const cardStyles = `
 `;
 
 const SitemapCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   const normalSiteMap = props.data.url || props.data.urlset?.url || null;
   const siteMapIndex = props.data.sitemapindex?.sitemap || null;
 
@@ -56,7 +58,14 @@ const SitemapCard = (props: { data: any; title: string; actionButtons: any }): J
             ></ExpandableRow>
           );
         })}
-      {siteMapIndex && <p>This site returns a sitemap index, which is a list of sitemaps.</p>}
+      {siteMapIndex && (
+        <p>
+          {localizeText(
+            'This site returns a sitemap index, which is a list of sitemaps.',
+            language,
+          )}
+        </p>
+      )}
       {siteMapIndex &&
         siteMapIndex.map((subpage: any, index: number) => {
           return (

--- a/src/client/components/Results/SocialTags.tsx
+++ b/src/client/components/Results/SocialTags.tsx
@@ -1,6 +1,7 @@
 import { Card } from 'client/components/Form/Card';
 import Row from 'client/components/Form/Row';
 import colors from 'client/styles/colors';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const cardStyles = `
   .banner-image img {
@@ -17,15 +18,17 @@ const cardStyles = `
 `;
 
 const OgBanner = ({ ogImage, ogUrl }: { ogImage: string; ogUrl?: string }): JSX.Element => {
+  const { language } = useLanguage();
   const urlCover = ogImage.startsWith('/') && ogUrl ? `${ogUrl}${ogImage}` : ogImage;
   return (
     <div className="banner-image">
-      <img src={urlCover} alt="Banner" />
+      <img src={urlCover} alt={language === 'zh-CN' ? '社交分享横幅' : 'Social preview banner'} />
     </div>
   );
 };
 
 const SocialTagsCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   const tags = props.data;
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
@@ -35,7 +38,7 @@ const SocialTagsCard = (props: { data: any; title: string; actionButtons: any })
       {tags.canonicalUrl && <Row lbl="Canonical URL" val={tags.canonicalUrl} />}
       {tags.themeColor && (
         <Row lbl="" val="">
-          <span className="lbl">Theme Color</span>
+          <span className="lbl">{localizeText('Theme Color', language)}</span>
           <span className="val color-field" style={{ background: tags.themeColor }}>
             {tags.themeColor}
           </span>
@@ -43,7 +46,7 @@ const SocialTagsCard = (props: { data: any; title: string; actionButtons: any })
       )}
       {tags.twitterSite && (
         <Row lbl="" val="">
-          <span className="lbl">Twitter Site</span>
+          <span className="lbl">{localizeText('Twitter Site', language)}</span>
           <span className="val">
             <a href={`https://x.com/${tags.twitterSite}`}>{tags.twitterSite}</a>
           </span>

--- a/src/client/components/Results/Threats.tsx
+++ b/src/client/components/Results/Threats.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import colors from 'client/styles/colors';
 import { Card } from 'client/components/Form/Card';
 import Row, { ExpandableRow } from 'client/components/Form/Row';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const Expandable = styled.details`
   margin-top: 0.5rem;
@@ -31,6 +32,7 @@ const convertToDate = (dateString: string): string => {
 };
 
 const MalwareCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   const urlHaus = props.data.urlHaus || {};
   const phishTank = props.data.phishTank || {};
   const cloudmersive = props.data.cloudmersive || {};
@@ -60,7 +62,7 @@ const MalwareCard = (props: { data: any; title: string; actionButtons: any }): J
       )}
       {phishTank.url0?.valid === 'true' && phishTank.url0.phish_detail_page && (
         <Row lbl="" val="">
-          <span className="lbl">Phish Info</span>
+          <span className="lbl">{localizeText('Phish Info', language)}</span>
           <span className="val">
             <a href={phishTank.url0.phish_detail_page}>{phishTank.url0.phish_id}</a>
           </span>
@@ -78,7 +80,7 @@ const MalwareCard = (props: { data: any; title: string; actionButtons: any }): J
       )}
       {urlHaus.urls && (
         <Expandable>
-          <summary>Expand Results</summary>
+          <summary>{localizeText('Expand Results', language)}</summary>
           {urlHaus.urls.map((urlResult: any) => {
             const rows = [
               { lbl: 'ID', val: urlResult.id },

--- a/src/client/components/Results/TlsConnection.tsx
+++ b/src/client/components/Results/TlsConnection.tsx
@@ -1,6 +1,7 @@
 import { Card } from 'client/components/Form/Card';
 import Row from 'client/components/Form/Row';
 import colors from 'client/styles/colors';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const yesNo = (v: boolean) => (v ? '✅ Yes' : '❌ No');
 
@@ -17,6 +18,7 @@ const TlsConnectionCard = (props: {
   title: string;
   actionButtons: any;
 }): JSX.Element => {
+  const { language } = useLanguage();
   const d = props.data || {};
   const cipherName = d.cipher?.standardName || d.cipher?.name || '';
   const ephemeral = formatEphemeralKey(d.ephemeralKey);
@@ -30,9 +32,12 @@ const TlsConnectionCard = (props: {
       <Row lbl="Forward Secrecy" val={yesNo(!!d.forwardSecrecy)} />
       <Row lbl="Session Resumption" val={yesNo(!!d.sessionResumption)} />
       <Row lbl="OCSP Stapling" val="">
-        <span className="lbl">OCSP Stapling</span>
+        <span className="lbl">{localizeText('OCSP Stapling', language)}</span>
         <span className="val" style={{ color: colors.info }}>
-          {d.ocspStapled ? 'ⓘ Present' : 'ⓘ Not Present (may impact visitor privacy)'}
+          {localizeText(
+            d.ocspStapled ? 'ⓘ Present' : 'ⓘ Not Present (may impact visitor privacy)',
+            language,
+          )}
         </span>
       </Row>
       <Row

--- a/src/client/components/Results/TraceRoute.tsx
+++ b/src/client/components/Results/TraceRoute.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import colors from 'client/styles/colors';
 import { Card } from 'client/components/Form/Card';
+import { useLanguage } from 'client/i18n';
 
 const RouteRow = styled.div`
   text-align: center;
@@ -33,6 +34,7 @@ const RouteTimings = styled.div`
 const cardStyles = ``;
 
 const TraceRouteCard = (props: { data: any; title: string; actionButtons: any }): JSX.Element => {
+  const { language } = useLanguage();
   const traceRouteResponse = props.data;
   const routes = traceRouteResponse.result;
   return (
@@ -45,8 +47,12 @@ const TraceRouteCard = (props: { data: any; title: string; actionButtons: any })
             <RouteTimings>
               {route[Object.keys(route)[0]].map((time: any, packetIndex: number) => (
                 <p className="times" key={`timing-${packetIndex}-${time}`}>
-                  {route[Object.keys(route)[0]].length > 1 && <>Packet #{packetIndex + 1}:</>}
-                  Took {time} ms
+                  {route[Object.keys(route)[0]].length > 1 && (
+                    <>
+                      {language === 'zh-CN' ? '数据包' : 'Packet'} #{packetIndex + 1}:{' '}
+                    </>
+                  )}
+                  {language === 'zh-CN' ? `耗时 ${time} 毫秒` : `Took ${time} ms`}
                 </p>
               ))}
               <p className="arrow">↓</p>
@@ -54,7 +60,11 @@ const TraceRouteCard = (props: { data: any; title: string; actionButtons: any })
           </RouteRow>
         ))}
       <RouteTimings>
-        <p className="completed">Round trip completed in {traceRouteResponse.timeTaken} ms</p>
+        <p className="completed">
+          {language === 'zh-CN'
+            ? `往返完成，耗时 ${traceRouteResponse.timeTaken} 毫秒`
+            : `Round trip completed in ${traceRouteResponse.timeTaken} ms`}
+        </p>
       </RouteTimings>
     </Card>
   );

--- a/src/client/components/Results/Vulnerabilities.tsx
+++ b/src/client/components/Results/Vulnerabilities.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import colors from 'client/styles/colors';
 import { Card } from 'client/components/Form/Card';
 import Row from 'client/components/Form/Row';
+import { useLanguage } from 'client/i18n';
 
 const cardStyles = `
   ul {
@@ -32,11 +33,14 @@ const VulnerabilitiesCard = (props: {
   title: string;
   actionButtons: any;
 }): JSX.Element => {
+  const { language } = useLanguage();
   const vulns: string[] = props.data.vulns || [];
   return (
     <Card heading={props.title} actionButtons={props.actionButtons} styles={cardStyles}>
       {vulns.length === 0 ? (
-        <AllClear>✅ No known active vulnerabilities</AllClear>
+        <AllClear>
+          ✅ {language === 'zh-CN' ? '未发现已知的活跃漏洞' : 'No known active vulnerabilities'}
+        </AllClear>
       ) : (
         <>
           <Row lbl="Known CVEs" val={vulns.length.toString()} />

--- a/src/client/components/boundaries/PageError.tsx
+++ b/src/client/components/boundaries/PageError.tsx
@@ -8,6 +8,7 @@ import Nav from 'client/components/Form/Nav';
 import Button from 'client/components/Form/Button';
 import { StyledCard } from 'client/components/Form/Card';
 import { Link } from 'react-router';
+import { useLanguage, type Language } from 'client/i18n';
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -17,6 +18,10 @@ interface ErrorBoundaryState {
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
+}
+
+interface InnerProps extends ErrorBoundaryProps {
+  language: Language;
 }
 
 const ErrorPageContainer = styled.div`
@@ -63,8 +68,8 @@ const ErrorMessageText = styled.p`
   color: ${colors.danger};
 `;
 
-class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  constructor(props: ErrorBoundaryProps) {
+class ErrorBoundaryInner extends React.Component<InnerProps, ErrorBoundaryState> {
+  constructor(props: InnerProps) {
     super(props);
     this.state = { hasError: false, errorCount: 0, errorMessage: null };
   }
@@ -92,45 +97,53 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
 
   render() {
     if (this.state.hasError) {
+      const isChinese = this.props.language === 'zh-CN';
       return (
         <ErrorPageContainer>
           <Nav>
             <HeaderLinkContainer>
               <Link to="/">
-                <Button>Go back Home</Button>
+                <Button>{isChinese ? '返回首页' : 'Go back Home'}</Button>
               </Link>
               <a target="_blank" rel="noreferrer" href="https://github.com/lissy93/web-check">
-                <Button>View on GitHub</Button>
+                <Button>{isChinese ? '在 GitHub 查看' : 'View on GitHub'}</Button>
               </a>
             </HeaderLinkContainer>
           </Nav>
           <ErrorInner>
             <Heading as="h1" size="medium" color={colors.primary}>
-              Something's gone wrong
+              {isChinese ? '出现了一些问题' : "Something's gone wrong"}
             </Heading>
             <Heading as="h2" size="small" color={colors.textColor}>
-              An unexpected error occurred.
+              {isChinese ? '发生了意外错误。' : 'An unexpected error occurred.'}
             </Heading>
             <Heading as="h3" size="large" color={colors.textColor}>
               🤯
             </Heading>
             <ErrorDetails>
               <p>
-                We're sorry this happened. Usually reloading the page will resolve this, but if it
-                doesn't, please raise a bug report.
+                {isChinese
+                  ? '很抱歉出现这个问题。重新加载页面通常可以解决；如果仍未恢复，请提交错误报告。'
+                  : "We're sorry this happened. Usually reloading the page will resolve this, but if it doesn't, please raise a bug report."}
               </p>
               {this.state.errorMessage && (
                 <p>
-                  Below is the error message we received:
+                  {isChinese ? '收到的错误消息如下：' : 'Below is the error message we received:'}
                   <br />
                   <br />
                   <ErrorMessageText>{this.state.errorMessage}</ErrorMessageText>
                 </p>
               )}
             </ErrorDetails>
-            <Button onClick={() => window.location.reload()}>Reload Page</Button>
-            <a target="_blank" rel="noreferrer" href="github.com/lissy93/web-check/issues/choose">
-              Report Issue
+            <Button onClick={() => window.location.reload()}>
+              {isChinese ? '重新加载页面' : 'Reload Page'}
+            </Button>
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href="https://github.com/lissy93/web-check/issues/choose"
+            >
+              {isChinese ? '报告问题' : 'Report Issue'}
             </a>
           </ErrorInner>
           <Footer isFixed={true} />
@@ -141,5 +154,10 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     return this.props.children;
   }
 }
+
+const ErrorBoundary = (props: ErrorBoundaryProps) => {
+  const { language } = useLanguage();
+  return <ErrorBoundaryInner {...props} language={language} />;
+};
 
 export default ErrorBoundary;

--- a/src/client/components/misc/AdditionalResources.tsx
+++ b/src/client/components/misc/AdditionalResources.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import colors from 'client/styles/colors';
 import { Card } from 'client/components/Form/Card';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const ResourceListOuter = styled.ul`
   list-style: none;
@@ -281,8 +282,9 @@ const makeLink = (resource: any, scanUrl: string | undefined): string => {
 };
 
 const AdditionalResources = (props: { url?: string }): JSX.Element => {
+  const { language, t } = useLanguage();
   return (
-    <Card heading="External Tools for Further Research" styles={CardStyles}>
+    <Card heading={t('externalTools')} styles={CardStyles}>
       <ResourceListOuter>
         {resources.map((resource, index) => {
           return (
@@ -304,7 +306,9 @@ const AdditionalResources = (props: { url?: string }): JSX.Element => {
                 <div className="resource-lower">
                   <img src={resource.icon} alt="" />
                   <div className="resource-details">
-                    <p className="resource-description">{resource.description}</p>
+                    <p className="resource-description">
+                      {localizeText(resource.description, language)}
+                    </p>
                   </div>
                 </div>
               </a>
@@ -313,7 +317,7 @@ const AdditionalResources = (props: { url?: string }): JSX.Element => {
         })}
       </ResourceListOuter>
       <Note>
-        These tools are not affiliated with Web-Check. Please use them at your own risk.
+        {t('externalToolsNote')}
         <br />
         At the time of listing, all of the above were available and free to use - if this changes,
         please report it via GitHub (

--- a/src/client/components/misc/AdvisoryPanel.tsx
+++ b/src/client/components/misc/AdvisoryPanel.tsx
@@ -4,6 +4,7 @@ import colors from 'client/styles/colors';
 import Card from 'client/components/Form/Card';
 import Heading from 'client/components/Form/Heading';
 import type { Finding, Severity } from 'client/analysis/types';
+import { localizeText, useLanguage } from 'client/i18n';
 
 const ORDER: Severity[] = ['critical', 'issue', 'warning', 'info', 'pass'];
 
@@ -108,6 +109,7 @@ interface Props {
 
 // Group findings by severity, render summary + collapsible sections, hide when empty
 const AdvisoryPanel = ({ findings, onJumpTo }: Props): ReactNode => {
+  const { language, t } = useLanguage();
   const { grouped, visible } = useMemo(() => {
     const grouped: Record<Severity, Finding[]> = {
       critical: [],
@@ -125,7 +127,7 @@ const AdvisoryPanel = ({ findings, onJumpTo }: Props): ReactNode => {
   return (
     <Wrapper>
       <Heading as="h2" align="left" color={colors.primary}>
-        Advisory
+        {t('advisory')}
       </Heading>
       {visible.map((sev) => {
         const meta = META[sev];
@@ -138,20 +140,24 @@ const AdvisoryPanel = ({ findings, onJumpTo }: Props): ReactNode => {
             style={{ background: `${meta.color}0D` }}
           >
             <summary style={{ color: meta.color }}>
-              {meta.label}
+              {localizeText(meta.label, language)}
               <span className="count">({items.length})</span>
             </summary>
             <ul className="findings">
               {items.map((f, i) => (
                 <li key={`${f.cardId}-${i}`}>
-                  <span className="glyph" style={{ color: meta.color }} aria-label={meta.label}>
+                  <span
+                    className="glyph"
+                    style={{ color: meta.color }}
+                    aria-label={localizeText(meta.label, language)}
+                  >
                     {meta.glyph}
                   </span>
                   <span className="body">
                     <button type="button" className="jump" onClick={() => onJumpTo(f.cardId)}>
-                      {f.title}
+                      {localizeText(f.title, language)}
                     </button>
-                    {f.detail && <span className="detail">{f.detail}</span>}
+                    {f.detail && <span className="detail">{localizeText(f.detail, language)}</span>}
                   </span>
                 </li>
               ))}

--- a/src/client/components/misc/DocContent.tsx
+++ b/src/client/components/misc/DocContent.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import docs, { type Doc } from 'client/utils/docs';
 import colors from 'client/styles/colors';
 import Heading from 'client/components/Form/Heading';
+import { localizeDoc, useLanguage } from 'client/i18n';
 
 const JobDocsContainer = styled.div`
   p.doc-desc,
@@ -26,23 +27,25 @@ const JobDocsContainer = styled.div`
   }
 `;
 
-const DocContent = (id: string) => {
-  const doc = docs.filter((doc: Doc) => doc.id === id)[0] || null;
+const DocContent = ({ id }: { id: string }) => {
+  const { language, t } = useLanguage();
+  const sourceDoc = docs.filter((doc: Doc) => doc.id === id)[0] || null;
+  const doc = sourceDoc ? localizeDoc(sourceDoc, language) : null;
   return doc ? (
     <JobDocsContainer>
       <Heading as="h3" size="medium" color={colors.primary}>
         {doc.title}
       </Heading>
       <Heading as="h4" size="small">
-        About
+        {t('docsAbout')}
       </Heading>
       <p className="doc-desc">{doc.description}</p>
       <Heading as="h4" size="small">
-        Use Cases
+        {t('docsUses')}
       </Heading>
       <p className="doc-uses">{doc.use}</p>
       <Heading as="h4" size="small">
-        Links
+        {t('docsLinks')}
       </Heading>
       <ul>
         {doc.resources.map((resource: string | { title: string; link: string }, index: number) =>
@@ -64,15 +67,19 @@ const DocContent = (id: string) => {
       <details>
         <summary>
           <Heading as="h4" size="small">
-            Example
+            {t('docsExample')}
           </Heading>
         </summary>
-        <img width="300" src={doc.screenshot} alt="Screenshot" />
+        <img
+          width="300"
+          src={doc.screenshot}
+          alt={language === 'zh-CN' ? '示例截图' : 'Example screenshot'}
+        />
       </details>
     </JobDocsContainer>
   ) : (
     <JobDocsContainer>
-      <p>No Docs provided for this widget yet</p>
+      <p>{t('noDocs')}</p>
     </JobDocsContainer>
   );
 };

--- a/src/client/components/misc/ErrorBoundary.tsx
+++ b/src/client/components/misc/ErrorBoundary.tsx
@@ -3,11 +3,16 @@ import styled from '@emotion/styled';
 import Card from 'client/components/Form/Card';
 import Heading from 'client/components/Form/Heading';
 import colors from 'client/styles/colors';
+import { useLanguage, type Language } from 'client/i18n';
 
 interface Props {
   children: ReactNode;
   title?: string;
   key?: string;
+}
+
+interface InnerProps extends Props {
+  language: Language;
 }
 
 interface State {
@@ -19,7 +24,7 @@ const ErrorText = styled.p`
   color: ${colors.danger};
 `;
 
-class ErrorBoundary extends Component<Props, State> {
+class ErrorBoundaryInner extends Component<InnerProps, State> {
   public state: State = {
     hasError: false,
     errorMessage: null,
@@ -36,18 +41,21 @@ class ErrorBoundary extends Component<Props, State> {
 
   public render() {
     if (this.state.hasError) {
+      const isChinese = this.props.language === 'zh-CN';
       return (
         <Card>
           {this.props.title && <Heading color={colors.primary}>{this.props.title}</Heading>}
-          <ErrorText>This component errored unexpectedly</ErrorText>
+          <ErrorText>
+            {isChinese ? '此组件发生了意外错误' : 'This component errored unexpectedly'}
+          </ErrorText>
           <p>
-            Usually this happens if the result from the server was not what was expected. Check the
-            logs for more info. If you continue to experience this issue, please raise a ticket on
-            the repository.
+            {isChinese
+              ? '这通常是因为服务器返回了非预期结果。请查看日志以了解详情；如果问题持续出现，请在项目仓库提交问题。'
+              : 'Usually this happens if the result from the server was not what was expected. Check the logs for more info. If you continue to experience this issue, please raise a ticket on the repository.'}
           </p>
           {this.state.errorMessage && (
             <details>
-              <summary>Error Details</summary>
+              <summary>{isChinese ? '错误详情' : 'Error Details'}</summary>
               <div>{this.state.errorMessage}</div>
             </details>
           )}
@@ -58,5 +66,10 @@ class ErrorBoundary extends Component<Props, State> {
     return this.props.children;
   }
 }
+
+const ErrorBoundary = (props: Props) => {
+  const { language } = useLanguage();
+  return <ErrorBoundaryInner {...props} language={language} />;
+};
 
 export default ErrorBoundary;

--- a/src/client/components/misc/Footer.tsx
+++ b/src/client/components/misc/Footer.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { Link } from 'react-router';
 import colors from 'client/styles/colors';
+import { useLanguage } from 'client/i18n';
 
 const StyledFooter = styled.footer`
   bottom: 0;
@@ -41,17 +42,18 @@ const ALink = styled.a`
 `;
 
 const Footer = (props: { isFixed?: boolean }): JSX.Element => {
+  const { t } = useLanguage();
   const licenseUrl = 'https://github.com/lissy93/web-check/blob/master/LICENSE';
   const authorUrl = 'https://aliciasykes.com';
   const githubUrl = 'https://github.com/lissy93/web-check';
   return (
     <StyledFooter style={props.isFixed ? { position: 'fixed' } : {}}>
       <span>
-        View source at <ALink href={githubUrl}>github.com/lissy93/web-check</ALink>
+        {t('sourceAt')} <ALink href={githubUrl}>github.com/lissy93/web-check</ALink>
       </span>
       <span>
-        <Link to="/about">Web-Check</Link> is licensed under <ALink href={licenseUrl}>MIT</ALink> -
-        © <ALink href={authorUrl}>Alicia Sykes</ALink> 2026
+        <Link to="/about">Web-Check</Link> {t('licensed')} <ALink href={licenseUrl}>MIT</ALink> - ©{' '}
+        <ALink href={authorUrl}>Alicia Sykes</ALink> 2026
       </span>
     </StyledFooter>
   );

--- a/src/client/components/misc/LanguageSwitcher.tsx
+++ b/src/client/components/misc/LanguageSwitcher.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+import colors from 'client/styles/colors';
+import { useLanguage, type Language } from 'client/i18n';
+
+const Switcher = styled.div`
+  display: inline-grid;
+  grid-template-columns: repeat(2, minmax(3rem, auto));
+  height: 2rem;
+  padding: 2px;
+  border: 1px solid ${colors.primaryTransparent};
+  border-radius: 4px;
+  background: ${colors.background};
+  flex: 0 0 auto;
+  button {
+    min-width: 0;
+    border: 0;
+    border-radius: 2px;
+    padding: 0 0.55rem;
+    background: transparent;
+    color: ${colors.textColorSecondary};
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    line-height: 1;
+    cursor: pointer;
+    white-space: nowrap;
+    &[aria-pressed='true'] {
+      background: ${colors.primary};
+      color: ${colors.background};
+      font-weight: 700;
+    }
+    &:focus-visible {
+      outline: 2px solid ${colors.primary};
+      outline-offset: 2px;
+    }
+  }
+`;
+
+const LanguageSwitcher = ({ className }: { className?: string }) => {
+  const { language, setLanguage, t } = useLanguage();
+  const options: Array<{ value: Language; label: string; title: string }> = [
+    { value: 'en', label: 'EN', title: t('english') },
+    { value: 'zh-CN', label: '中文', title: t('chinese') },
+  ];
+  return (
+    <Switcher className={className} role="group" aria-label={t('language')}>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          title={option.title}
+          aria-pressed={language === option.value}
+          onClick={() => setLanguage(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </Switcher>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/client/components/misc/Loader.tsx
+++ b/src/client/components/misc/Loader.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { StyledCard } from 'client/components/Form/Card';
 import Heading from 'client/components/Form/Heading';
 import colors from 'client/styles/colors';
+import { useLanguage } from 'client/i18n';
 
 const LoaderContainer = styled(StyledCard)`
   margin: 0 auto;
@@ -54,10 +55,11 @@ const StyledSvg = styled.svg`
 `;
 
 const Loader = (props: { show: boolean }): JSX.Element => {
+  const { t } = useLanguage();
   return (
     <LoaderContainer className={props.show ? '' : 'finished'}>
       <Heading as="h4" color={colors.primary}>
-        Crunching data...
+        {t('crunching')}
       </Heading>
       <StyledSvg
         version="1.1"
@@ -115,9 +117,9 @@ const Loader = (props: { show: boolean }): JSX.Element => {
         </path>
       </StyledSvg>
       <p className="loadTimeInfo">
-        It may take up-to a minute for all jobs to complete
+        {t('loadWait')}
         <br />
-        You can view preliminary results as they come in below
+        {t('preliminary')}
       </p>
     </LoaderContainer>
   );

--- a/src/client/components/misc/NoResults.tsx
+++ b/src/client/components/misc/NoResults.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import colors from 'client/styles/colors';
 import { StyledCard } from 'client/components/Form/Card';
 import Heading from 'client/components/Form/Heading';
+import { useLanguage } from 'client/i18n';
 
 const Wrapper = styled(StyledCard)`
   margin: 0 auto;
@@ -91,6 +92,55 @@ const VARIANT: Record<Kind, { title: string; description: string; reasons: strin
   },
 };
 
+const VARIANT_ZH: typeof VARIANT = {
+  unreachable: {
+    title: '无法访问该站点',
+    description: '无法解析该主机的 IP 地址，因此不能继续检查',
+    reasons: [
+      '域名可能拼写错误或已注销',
+      '网站可能离线或暂时无法访问',
+      'DNS 解析可能出现问题',
+      '防火墙或地域限制可能阻止访问',
+    ],
+  },
+  invalid: {
+    title: '输入无效',
+    description: '输入内容不是有效的网址或 IP 地址，因此不能继续检查',
+    reasons: [
+      '请输入域名（例如 example.com）或 IPv4 / IPv6 地址',
+      '检查输入中的拼写错误或多余字符',
+      '请勿包含空格或不支持的符号',
+    ],
+  },
+  'api-down': {
+    title: '服务不可用',
+    description: '由于无法连接 Web Check API，大部分检查均失败',
+    reasons: [
+      'API 可能离线、重启中或触发限流',
+      '自托管实例可能配置错误或未运行',
+      '网络或防火墙可能拦截了 API',
+    ],
+  },
+  blocked: {
+    title: '不允许扫描',
+    description: '当前实例不允许扫描该主机，因此所有检查均已跳过',
+    reasons: [
+      '管理员可能已屏蔽该域名或 IP 网段',
+      '实例可能禁用了相关检查',
+      '仍可在自己的 Web Check 实例中扫描该主机',
+    ],
+  },
+  disabled: {
+    title: 'Web Check 已暂停',
+    description: '当前实例已暂时停用，因此不能执行检查',
+    reasons: [
+      '公共实例可能为控制运行成本而暂停',
+      '自托管实例可能正在维护',
+      '可以从 GitHub 开源仓库运行自己的实例',
+    ],
+  },
+};
+
 interface Props {
   address: string;
   error?: string;
@@ -99,7 +149,8 @@ interface Props {
 
 // Surface a friendly explanation when input is invalid or the host is unreachable
 const NoResults = ({ address, error, kind = 'unreachable' }: Props): JSX.Element => {
-  const { title, description, reasons } = VARIANT[kind];
+  const { language, t } = useLanguage();
+  const { title, description, reasons } = (language === 'zh-CN' ? VARIANT_ZH : VARIANT)[kind];
   return (
     <Wrapper role="alert">
       <Heading as="h2" align="left" color={colors.danger}>
@@ -107,7 +158,7 @@ const NoResults = ({ address, error, kind = 'unreachable' }: Props): JSX.Element
       </Heading>
       <p>{description}</p>
       <code className="target">{address}</code>
-      <p>Possible reasons:</p>
+      <p>{t('possibleReasons')}</p>
       <ul className="reasons">
         {reasons.map((r) => (
           <li key={r}>{r}</li>
@@ -115,7 +166,7 @@ const NoResults = ({ address, error, kind = 'unreachable' }: Props): JSX.Element
       </ul>
       {error && (
         <span className="detail">
-          {kind === 'blocked' ? 'Reason' : 'Lookup error'}: {error}
+          {kind === 'blocked' ? t('reason').replace('：', '') : t('lookupError')}: {error}
         </span>
       )}
     </Wrapper>

--- a/src/client/components/misc/ProgressBar.tsx
+++ b/src/client/components/misc/ProgressBar.tsx
@@ -4,6 +4,7 @@ import colors from 'client/styles/colors';
 import Card from 'client/components/Form/Card';
 import Heading from 'client/components/Form/Heading';
 import { allCardIds } from 'client/jobs/registry';
+import { localizeCardTitle, localizeText, useLanguage } from 'client/i18n';
 
 export type LoadingState = 'success' | 'loading' | 'skipped' | 'error' | 'timed-out';
 
@@ -288,27 +289,31 @@ interface JobListItemProps {
   showErrorModal: (job: LoadingJob, isInfo?: boolean) => void;
 }
 
-const REASON_LABEL: Partial<Record<LoadingState, string>> = {
-  error: '■ Show Error',
-  'timed-out': '■ Show Timeout Reason',
-  skipped: '■ Show Skip Reason',
-};
-
 // One row in the details list, showing job state, time and any actions
 const JobListItem = ({ job, showJobDocs, showErrorModal }: JobListItemProps): ReactNode => {
+  const { language, t } = useLanguage();
   const { name, state, timeTaken, retry, error } = job;
   const canRetry = retry && state !== 'success' && state !== 'loading';
-  const reasonLabel = error ? REASON_LABEL[state] : undefined;
+  const reasonLabel = error
+    ? state === 'error'
+      ? `■ ${t('showError')}`
+      : state === 'timed-out'
+        ? `■ ${t('showTimeout')}`
+        : state === 'skipped'
+          ? `■ ${t('showSkip')}`
+          : undefined
+    : undefined;
+  const displayName = localizeCardTitle(name, name, language);
   return (
     <li>
       <button type="button" className="docs" onClick={() => showJobDocs(name)}>
-        {STATE_META[state].emoji} {name}
+        {STATE_META[state].emoji} {displayName}
       </button>
-      <StateLabel color={STATE_META[state].color}> ({state})</StateLabel>
-      <i>{timeTaken && state !== 'loading' ? ` Took ${timeTaken} ms` : ''}</i>
+      <StateLabel color={STATE_META[state].color}> ({localizeText(state, language)})</StateLabel>
+      <i>{timeTaken && state !== 'loading' ? ` ${t('took', { time: timeTaken })}` : ''}</i>
       {canRetry && (
         <FailedJobActionButton type="button" onClick={retry}>
-          ↻ Retry
+          ↻ {t('retry')}
         </FailedJobActionButton>
       )}
       {reasonLabel && (
@@ -331,13 +336,15 @@ interface LoadSummaryProps {
 
 // Compact one-liner shown alongside the "Show Load State" button when collapsed
 const LoadSummary = ({ jobs, elapsedMs, onOpen }: LoadSummaryProps): ReactNode => {
+  const { t } = useLanguage();
   const total = allCardIds.length;
   const c = countByState(jobs);
   const issues = c.error + c['timed-out'] + c.skipped;
   const sec = (elapsedMs / 1000).toFixed(1);
   const text = c.loading
-    ? `Loading ${total - c.loading} of ${total}` + (elapsedMs < 15000 ? ` (${sec}s)` : '')
-    : `Finished ${total} lookups in ${sec}s`;
+    ? t('loadingLookups', { done: total - c.loading, total }) +
+      (elapsedMs < 15000 ? ` (${sec}s)` : '')
+    : t('finishedLookups', { total, seconds: sec });
   return (
     <span className="summary">
       {text}
@@ -345,7 +352,7 @@ const LoadSummary = ({ jobs, elapsedMs, onOpen }: LoadSummaryProps): ReactNode =
         <>
           {' · '}
           <button type="button" className="extras" onClick={onOpen}>
-            {issues} {issues === 1 ? 'issue' : 'issues'}
+            {issues} {t(issues === 1 ? 'issue' : 'issues')}
           </button>
         </>
       )}
@@ -369,6 +376,7 @@ interface SummaryTextProps {
 
 // Heading-style summary that adapts to loading, all-success and partial-failure
 const SummaryText = ({ jobs, elapsedMs }: SummaryTextProps): ReactNode => {
+  const { language, t } = useLanguage();
   const total = allCardIds.length;
   const c = countByState(jobs);
   const isDone = c.loading === 0;
@@ -377,14 +385,16 @@ const SummaryText = ({ jobs, elapsedMs }: SummaryTextProps): ReactNode => {
   const chip = (k: ChipKey) =>
     c[k] > 0 && (
       <span key={k} className={k}>
-        {c[k]} {c[k] === 1 ? 'job' : 'jobs'} {CHIP_LABEL[k]}{' '}
+        {language === 'zh-CN'
+          ? `${c[k]} 项${localizeText(CHIP_LABEL[k], language)}`
+          : `${c[k]} ${c[k] === 1 ? 'job' : 'jobs'} ${CHIP_LABEL[k]}`}{' '}
       </span>
     );
   const cls = !isDone ? 'loading-info' : hasIssues ? 'error-info' : 'success-info';
   const heading = !isDone
-    ? `Loading ${total - c.loading} / ${total} Jobs`
+    ? t('loadingJobs', { done: total - c.loading, total })
     : !hasIssues
-      ? `${c.success} Jobs Completed Successfully`
+      ? t('completedJobs', { count: c.success })
       : null;
   const keys: ChipKey[] = !isDone
     ? ['skipped', 'timed-out', 'error']
@@ -395,7 +405,7 @@ const SummaryText = ({ jobs, elapsedMs }: SummaryTextProps): ReactNode => {
     <SummaryContainer className={cls}>
       {heading && <b>{heading}</b>}
       {keys.map(chip)}
-      <span className="elapsed">{isDone ? `Done in ${elapsed}` : elapsed}</span>
+      <span className="elapsed">{isDone ? t('doneIn', { time: elapsed }) : elapsed}</span>
     </SummaryContainer>
   );
 };
@@ -408,6 +418,7 @@ interface ProgressLoaderProps {
 
 // Top-of-results progress bar with collapsible per-job detail and error modals
 const ProgressLoader = ({ loadStatus, showModal, showJobDocs }: ProgressLoaderProps): ReactNode => {
+  const { language, t } = useLanguage();
   const [hideLoader, setHideLoader] = useState(false);
   const [elapsedMs, setElapsedMs] = useState(0);
   const percentages = stateToPercent(loadStatus);
@@ -438,13 +449,15 @@ const ProgressLoader = ({ loadStatus, showModal, showJobDocs }: ProgressLoaderPr
     state === 'success' && isDone ? colors.primary : STATE_META[state].color;
 
   const showErrorModal = (job: LoadingJob, isInfo?: boolean) => {
-    const detailsLabel = job.state === 'skipped' ? 'Reason:' : 'Server response:';
+    const detailsLabel = job.state === 'skipped' ? t('reason') : t('serverResponse');
+    const displayName = localizeCardTitle(job.name, job.name, language);
     showModal(
       <ErrorModalContent>
-        <Heading as="h3">Details for {job.name}</Heading>
+        <Heading as="h3">{t('jobDetails', { name: displayName })}</Heading>
         <p>
-          The {job.name} job ended with state '{job.state}'
-          {job.timeTaken !== undefined ? ` after ${job.timeTaken} ms` : ''}. {detailsLabel}
+          {t('jobEnded', { name: displayName, state: localizeText(job.state, language) })}
+          {job.timeTaken !== undefined ? t('afterMs', { time: job.timeTaken }) : '. '}
+          {detailsLabel}
         </p>
         <pre className={isInfo ? 'info' : 'error'}>{job.error}</pre>
       </ErrorModalContent>,
@@ -462,7 +475,7 @@ const ProgressLoader = ({ loadStatus, showModal, showJobDocs }: ProgressLoaderPr
               onOpen={() => setHideLoader(false)}
             />
             <ShowLoadStateButton type="button" onClick={() => setHideLoader(false)}>
-              Show Load State
+              {t('showLoadState')}
             </ShowLoadStateButton>
           </ReShowRow>
         </div>
@@ -476,13 +489,13 @@ const ProgressLoader = ({ loadStatus, showModal, showJobDocs }: ProgressLoaderPr
                   key={`progress-bar-${state}`}
                   color={colorFor(state)}
                   width={percentages[state]}
-                  title={`${state} (${Math.round(percentages[state])}%)`}
+                  title={`${localizeText(state, language)} (${Math.round(percentages[state])}%)`}
                 />
               ))}
             </ProgressBarContainer>
             <SummaryText jobs={loadStatus} elapsedMs={elapsedMs} />
             <Details>
-              <summary>Show Details</summary>
+              <summary>{t('showDetails')}</summary>
               <ul>
                 {loadStatus.map((job) => (
                   <JobListItem
@@ -495,18 +508,17 @@ const ProgressLoader = ({ loadStatus, showModal, showJobDocs }: ProgressLoaderPr
               </ul>
               {loadStatus.some((j) => j.state === 'error') && (
                 <p className="error">
-                  <b>Check the browser console for logs and more info</b>
+                  <b>{t('checkConsole')}</b>
                   <br />
-                  It's normal for some jobs to fail, either because the host doesn't return the
-                  required info, or restrictions in the lambda function, or hitting an API limit.
+                  {t('normalFailures')}
                 </p>
               )}
               <AboutPageLink href="/check/about" target="_blank" rel="noreferrer">
-                Learn More about Web-Check
+                {t('learnMore')}
               </AboutPageLink>
             </Details>
             <DismissButton type="button" onClick={() => setHideLoader(true)}>
-              Dismiss
+              {t('dismiss')}
             </DismissButton>
           </LoadCard>
         </div>

--- a/src/client/components/misc/SelfScanMsg.tsx
+++ b/src/client/components/misc/SelfScanMsg.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import colors from 'client/styles/colors';
 import { StyledCard } from 'client/components/Form/Card';
+import { useLanguage } from 'client/i18n';
 
 const StyledSelfScanMsg = styled(StyledCard)`
   margin: 0px auto 1rem;
@@ -22,7 +23,7 @@ const StyledSelfScanMsg = styled(StyledCard)`
   }
 `;
 
-const messages = [
+const englishMessages = [
   "Nice try! But scanning this app is like trying to tickle yourself. It just doesn't work!",
   "Recursive scanning detected. The universe might implode...or it might not. But let's not try to find out.",
   "Hey, stop checking us out! We're blushing... 😉",
@@ -36,21 +37,47 @@ const messages = [
   "Ah, I see you're scanning this site... But alas, this did not cause an infinite recursive loop (this time)",
 ];
 
+const chineseMessages = [
+  '好尝试！但扫描这个应用就像挠自己痒痒，确实行不通。',
+  '检测到递归扫描。宇宙也许会坍缩，也许不会，还是别验证了。',
+  '别再检查我们啦，我们都不好意思了。',
+  '正在扫描我们吗？真让人受宠若惊。',
+  '警告：检测到镜像扫描。相信我们，状态很好。',
+  '很高兴你想扫描我们，但我们没法检查自己。',
+  '用检查器检查检查器？很有递归的味道。',
+  '等一下，你正在扫描我们？这个转折有点意思。',
+  '扫描我们，就像让镜子反省它自己。',
+  '这个场面有点尴尬：系统正在追踪自己。',
+  '原来你在扫描本站。不过这一次并没有触发无限递归。',
+];
+
 const SelfScanMsg = () => {
+  const { language } = useLanguage();
+  const messageIndex = Math.floor(Math.random() * englishMessages.length);
   return (
     <StyledSelfScanMsg>
-      <img src="https://i.ibb.co/0tQbCPJ/test2.png" alt="Self-Scan" />
-      <b>{messages[Math.floor(Math.random() * messages.length)]}</b>
+      <img
+        src="https://i.ibb.co/0tQbCPJ/test2.png"
+        alt={language === 'zh-CN' ? '自扫描' : 'Self-Scan'}
+      />
+      <b>{language === 'zh-CN' ? chineseMessages[messageIndex] : englishMessages[messageIndex]}</b>
       <br />
       <span>
-        But if you want to see how this site is built, why not check out the{' '}
+        {language === 'zh-CN'
+          ? '如果想了解本站的构建方式，可以查看'
+          : 'But if you want to see how this site is built, why not check out the '}
         <a target="_blank" rel="noreferrer" href="https://github.com/lissy93/web-check">
-          source code
+          {language === 'zh-CN' ? '源代码' : 'source code'}
         </a>
-        ?
+        {language === 'zh-CN' ? '。' : '?'}
       </span>
       <br />
-      <i>Do me a favour, and drop the repo a Star while you're there</i> 😉
+      <i>
+        {language === 'zh-CN'
+          ? '也欢迎顺手为项目点个 Star'
+          : "Do me a favour, and drop the repo a Star while you're there"}
+      </i>{' '}
+      😉
     </StyledSelfScanMsg>
   );
 };

--- a/src/client/components/misc/ViewRaw.tsx
+++ b/src/client/components/misc/ViewRaw.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import colors from 'client/styles/colors';
 import { Card } from 'client/components/Form/Card';
 import Button from 'client/components/Form/Button';
+import { useLanguage } from 'client/i18n';
 
 const CardStyles = `
 margin: 0 auto;
@@ -41,6 +42,7 @@ const StyledIframe = styled.iframe`
 `;
 
 const ViewRaw = (props: { everything: { id: string; result: any }[] }) => {
+  const { language, t } = useLanguage();
   const [resultUrl, setResultUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -82,25 +84,27 @@ const ViewRaw = (props: { everything: { id: string; result: any }[] }) => {
     URL.revokeObjectURL(url);
   };
   return (
-    <Card heading="View / Download Raw Data" styles={CardStyles}>
+    <Card heading={t('rawData')} styles={CardStyles}>
       <div className="controls">
-        <Button onClick={handleDownload}>Download Results</Button>
-        <Button onClick={fetchResultsUrl}>{resultUrl ? 'Update Results' : 'View Results'}</Button>
-        {resultUrl && <Button onClick={() => setResultUrl('')}>Hide Results</Button>}
+        <Button onClick={handleDownload}>{t('downloadResults')}</Button>
+        <Button onClick={fetchResultsUrl}>
+          {resultUrl ? t('updateResults') : t('viewResults')}
+        </Button>
+        {resultUrl && <Button onClick={() => setResultUrl('')}>{t('hideResults')}</Button>}
       </div>
       {resultUrl && !error && (
         <>
-          <StyledIframe title="Results, via JSON Hero" src={resultUrl} />
+          <StyledIframe
+            title={language === 'zh-CN' ? '通过 JSON Hero 查看结果' : 'Results via JSON Hero'}
+            src={resultUrl}
+          />
           <small>
-            Your results are available to view <a href={resultUrl}>here</a>.
+            <a href={resultUrl}>{t('resultsAvailable')}</a>
           </small>
         </>
       )}
       {error && <p className="error">{error}</p>}
-      <small>
-        These are the raw results generated from your URL, and in JSON format. You can import these
-        into your own program, for further analysis.
-      </small>
+      <small>{t('rawHint')}</small>
     </Card>
   );
 };

--- a/src/client/i18n.tsx
+++ b/src/client/i18n.tsx
@@ -1,0 +1,810 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type Language = 'en' | 'zh-CN';
+
+const STORAGE_KEY = 'web-check-language';
+
+const messages = {
+  en: {
+    language: 'Language',
+    english: 'English',
+    chinese: 'Chinese',
+    enterUrl: 'Enter a URL',
+    analyze: 'Analyze!',
+    emptyInput: 'Field must not be empty',
+    invalidInput: 'Must be a valid URL, IPv4 or IPv6 Address',
+    supportedChecks: 'Supported Checks',
+    enjoying: 'Enjoying Web Check?',
+    sponsorBefore:
+      "It's free, open source, and funded by the community. If it's been useful, you can keep it going (and ad-free) by",
+    sponsorLink: 'sponsoring me on GitHub',
+    sponsorAfter: 'Every bit genuinely helps, thank you.',
+    viewGithub: 'View on GitHub',
+    deployOwn: 'Deploy your own',
+    apiDocs: 'API Docs',
+    infoAbout: 'Info about {title}',
+    refetch: 'Re-fetch {title} data',
+    crunching: 'Crunching data...',
+    loadWait: 'It may take up to a minute for all jobs to complete',
+    preliminary: 'You can view preliminary results as they come in below',
+    advisory: 'Advisory',
+    showLoadState: 'Show Load State',
+    showDetails: 'Show Details',
+    dismiss: 'Dismiss',
+    learnMore: 'Learn More about Web-Check',
+    retry: 'Retry',
+    showError: 'Show Error',
+    showTimeout: 'Show Timeout Reason',
+    showSkip: 'Show Skip Reason',
+    serverResponse: 'Server response:',
+    reason: 'Reason:',
+    jobDetails: 'Details for {name}',
+    jobEnded: "The {name} job ended with state '{state}'",
+    afterMs: ' after {time} ms. ',
+    loadingJobs: 'Loading {done} / {total} Jobs',
+    completedJobs: '{count} Jobs Completed Successfully',
+    finishedLookups: 'Finished {total} lookups in {seconds}s',
+    loadingLookups: 'Loading {done} of {total}',
+    issues: 'issues',
+    issue: 'issue',
+    took: 'Took {time} ms',
+    doneIn: 'Done in {time}',
+    checkConsole: 'Check the browser console for logs and more info',
+    normalFailures:
+      "It's normal for some jobs to fail because the host may not return the required information, the runtime may restrict a check, or an API limit may have been reached.",
+    possibleReasons: 'Possible reasons:',
+    lookupError: 'Lookup error',
+    rawData: 'View / Download Raw Data',
+    downloadResults: 'Download Results',
+    updateResults: 'Update Results',
+    viewResults: 'View Results',
+    hideResults: 'Hide Results',
+    rawHint:
+      'These are the raw results generated from your URL in JSON format. You can import them into your own program for further analysis.',
+    resultsAvailable: 'Your results are available to view here.',
+    externalTools: 'External Tools for Further Research',
+    externalToolsNote:
+      'These tools are not affiliated with Web-Check. Please use them at your own risk.',
+    docsAbout: 'About',
+    docsUses: 'Use Cases',
+    docsLinks: 'Links',
+    docsExample: 'Example',
+    noDocs: 'No documentation is available for this widget yet.',
+    sourceAt: 'View source at',
+    licensed: 'is licensed under',
+    notFound: 'Not Found',
+    backHome: 'Back to Homepage',
+    reportIssue: 'Report Issue',
+  },
+  'zh-CN': {
+    language: '语言',
+    english: 'English',
+    chinese: '中文',
+    enterUrl: '输入网址',
+    analyze: '开始分析',
+    emptyInput: '网址不能为空',
+    invalidInput: '请输入有效的网址、IPv4 或 IPv6 地址',
+    supportedChecks: '支持的检查项目',
+    enjoying: '觉得 Web Check 好用吗？',
+    sponsorBefore: 'Web Check 免费、开源，并由社区支持。如果它对你有帮助，可以通过',
+    sponsorLink: 'GitHub 赞助',
+    sponsorAfter: '帮助项目持续运行并保持无广告。感谢每一份支持。',
+    viewGithub: '在 GitHub 查看',
+    deployOwn: '部署自己的实例',
+    apiDocs: 'API 文档',
+    infoAbout: '查看“{title}”说明',
+    refetch: '重新获取“{title}”数据',
+    crunching: '正在分析数据...',
+    loadWait: '全部检查最多可能需要一分钟',
+    preliminary: '检查过程中会在下方持续显示已返回的结果',
+    advisory: '安全建议',
+    showLoadState: '显示加载状态',
+    showDetails: '显示详情',
+    dismiss: '收起',
+    learnMore: '了解 Web Check',
+    retry: '重试',
+    showError: '查看错误',
+    showTimeout: '查看超时原因',
+    showSkip: '查看跳过原因',
+    serverResponse: '服务器响应：',
+    reason: '原因：',
+    jobDetails: '{name} 详情',
+    jobEnded: '任务 {name} 以“{state}”状态结束',
+    afterMs: '，耗时 {time} 毫秒。',
+    loadingJobs: '正在加载 {done} / {total} 项检查',
+    completedJobs: '{count} 项检查已成功完成',
+    finishedLookups: '{total} 项检查已完成，用时 {seconds} 秒',
+    loadingLookups: '正在加载 {done} / {total}',
+    issues: '个问题',
+    issue: '个问题',
+    took: '耗时 {time} 毫秒',
+    doneIn: '完成用时 {time}',
+    checkConsole: '请查看浏览器控制台日志以了解更多信息',
+    normalFailures:
+      '部分检查失败是正常现象，可能因为目标未返回所需信息、运行环境限制或触发 API 限额。',
+    possibleReasons: '可能的原因：',
+    lookupError: '查询错误',
+    rawData: '查看或下载原始数据',
+    downloadResults: '下载结果',
+    updateResults: '更新结果',
+    viewResults: '在线查看',
+    hideResults: '隐藏结果',
+    rawHint: '这是根据目标生成的 JSON 原始结果，可导入其他程序继续分析。',
+    resultsAvailable: '结果已生成，可点击此处查看。',
+    externalTools: '用于进一步研究的外部工具',
+    externalToolsNote: '这些工具与 Web Check 无关联，请自行判断并承担使用风险。',
+    docsAbout: '项目说明',
+    docsUses: '应用场景',
+    docsLinks: '相关链接',
+    docsExample: '示例',
+    noDocs: '暂时没有该检查项目的说明文档。',
+    sourceAt: '源代码：',
+    licensed: '采用',
+    notFound: '页面不存在',
+    backHome: '返回首页',
+    reportIssue: '报告问题',
+  },
+} as const;
+
+export type MessageKey = keyof (typeof messages)['en'];
+
+const cardTitles: Record<string, string> = {
+  location: '服务器位置',
+  ssl: 'SSL 证书',
+  domain: '域名 WHOIS',
+  whois: '域名信息',
+  quality: '网站质量概览',
+  'tech-stack': '技术栈',
+  hosts: '关联主机名',
+  'server-info': '服务器信息',
+  vulnerabilities: '已知漏洞',
+  cookies: 'Cookie',
+  headers: 'HTTP 响应头',
+  dns: 'DNS 记录',
+  'http-security': 'HTTP 安全配置',
+  'tls-connection': 'TLS 连接',
+  'tls-security-audit': 'TLS 安全审计',
+  'tls-client-compat': 'TLS 客户端兼容性',
+  subdomains: '子域名',
+  'trace-route': '路由追踪',
+  'security-txt': 'Security.txt',
+  'dns-server': 'DNS 服务器',
+  firewall: '防火墙',
+  dnssec: 'DNSSEC',
+  hsts: 'HSTS 检查',
+  threats: '恶意软件与钓鱼检测',
+  'mail-config': '邮件安全配置',
+  archives: '历史归档',
+  rank: '全球排名',
+  redirects: '重定向链',
+  'linked-pages': '页面链接',
+  'robots-txt': '爬虫规则',
+  status: '服务器状态',
+  ports: '开放端口',
+  'txt-records': 'TXT 记录',
+  'block-lists': '拦截名单检测',
+  sitemap: '站点页面',
+  screenshot: '网页截图',
+  'social-tags': '社交分享标签',
+  carbon: '碳足迹',
+};
+
+const chineseText: Record<string, string> = {
+  'First Scan': '首次收录',
+  'Last Scan': '最近收录',
+  'Days Archived': '归档天数',
+  'Change Count': '变更次数',
+  'Avg Size': '平均大小',
+  'Avg Days between Archives': '归档平均间隔天数',
+  'HTML Initial Size': 'HTML 初始大小',
+  'Adjusted Transfer Size': '估算传输大小',
+  'CO2 for Initial Load': '首次加载二氧化碳排放',
+  'Energy Usage for Load': '加载能耗',
+  'Cleaner than average page (est.)': '优于普通页面（估算）',
+  'Internal Link Count': '内部链接数',
+  'External Link Count': '外部链接数',
+  Cookies: 'Cookie',
+  None: '无',
+  Hostname: '主机名',
+  'IP Address': 'IP 地址',
+  'Registered Domain': '注册域名',
+  'Creation Date': '创建日期',
+  'Updated Date': '更新日期',
+  'Registry Expiry Date': '注册到期日期',
+  'Registry Domain ID': '注册局域名 ID',
+  'Registrar WHOIS Server': '注册商 WHOIS 服务器',
+  Registrar: '注册商',
+  'Registrar IANA ID': '注册商 IANA ID',
+  Firewall: '防火墙',
+  'HSTS Enabled?': '是否启用 HSTS',
+  'Content Security Policy': '内容安全策略',
+  'Strict Transport Policy': '严格传输策略',
+  'Referrer Policy': '来源信息策略',
+  'Permissions Policy': '权限策略',
+  'Historical Average Rank': '历史平均排名',
+  'Change since Yesterday': '较昨日变化',
+  Present: '是否存在',
+  'File Location': '文件位置',
+  'PGP Signed': 'PGP 签名',
+  Organization: '组织',
+  'Service Provider': '服务提供商',
+  'Operating System': '操作系统',
+  Ports: '端口',
+  Type: '类型',
+  Location: '位置',
+  City: '城市',
+  Country: '国家或地区',
+  Timezone: '时区',
+  Languages: '语言',
+  Currency: '货币',
+  'Status Code': '状态码',
+  'Response Time': '响应时间',
+  'Is Up?': '是否在线',
+  Title: '标题',
+  Description: '描述',
+  Keywords: '关键词',
+  'Canonical URL': '规范网址',
+  Author: '作者',
+  Publisher: '发布者',
+  Generator: '生成工具',
+  'Theme Color': '主题颜色',
+  'Twitter Site': 'Twitter 站点',
+  Subject: '主体',
+  Issuer: '签发者',
+  Trusted: '是否受信任',
+  Expires: '到期时间',
+  Renewed: '生效时间',
+  'Serial Num': '序列号',
+  Fingerprint: '指纹',
+  'Extended Key Usage': '扩展密钥用途',
+  'Base Domain': '根域名',
+  'Subdomains Found': '发现的子域名',
+  Showing: '当前显示',
+  'Google Safe Browsing': 'Google 安全浏览',
+  'Threat Type': '威胁类型',
+  'Phishing Status': '钓鱼状态',
+  'Phish Info': '钓鱼信息',
+  'Malware Status': '恶意软件状态',
+  Status: '状态',
+  'First Seen': '首次发现',
+  'Bad URLs Count': '恶意网址数量',
+  Protocol: '协议',
+  'Cipher Suite': '密码套件',
+  'Cipher Version': '密码版本',
+  'Ephemeral Key': '临时密钥',
+  'Forward Secrecy': '前向保密',
+  'Session Resumption': '会话恢复',
+  'OCSP Stapling': 'OCSP 装订',
+  'Certificate Trust': '证书信任',
+  Grade: '评级',
+  'Grade (trust ignored)': '评级（忽略信任）',
+  Protocols: '协议',
+  'Known CVEs': '已知 CVE',
+  Created: '创建时间',
+  Updated: '更新时间',
+  'Name Servers': '域名服务器',
+  Domains: '域名',
+  Hosts: '主机',
+  Algorithm: '算法',
+  Domain: '域名',
+  Flags: '标志',
+  'Public Key': '公钥',
+  'Key Tag': '密钥标签',
+  'Digest Type': '摘要类型',
+  Digest: '摘要',
+  'Recursion Available (RA)': '支持递归查询（RA）',
+  'Recursion Desired (RD)': '请求递归查询（RD）',
+  'TrunCation (TC)': '响应已截断（TC）',
+  'Authentic Data (AD)': '认证数据（AD）',
+  'Checking Disabled (CD)': '禁用验证（CD）',
+  'Change Frequency': '更新频率',
+  'Last Modified': '最后修改',
+  Priority: '优先级',
+  'Date Added': '添加日期',
+  'File Path': '文件路径',
+  'Reported By': '报告来源',
+  'Takedown Time': '下线耗时',
+  Reference: '参考链接',
+  Tags: '标签',
+  'No redirects': '无重定向',
+  'No TXT Records': '没有 TXT 记录',
+  '✅ Yes': '✅ 是',
+  '❌ No': '❌ 否',
+  '❌ No*': '❌ 否*',
+  '✅ Safe': '✅ 安全',
+  '❌ Unsafe': '❌ 不安全',
+  '✅ No Malwares Found': '✅ 未发现恶意软件',
+  '❌ Malware Identified': '❌ 发现恶意软件',
+  '✅ No Phishing Found': '✅ 未发现钓鱼',
+  '❌ Phishing Identified': '❌ 发现钓鱼',
+  Unknown: '未知',
+  'No crawl rules found.': '未发现爬虫规则。',
+  'View Full Policy': '查看完整策略',
+  'Expand Results': '展开结果',
+  'Unable to calculate carbon footprint for host': '无法计算该主机的碳足迹',
+  'This site returns a sitemap index, which is a list of sitemaps.':
+    '该站点返回的是站点地图索引，其中包含多个站点地图。',
+  'Not on any tested DNS blocklist': '未出现在已检测的 DNS 拦截名单中',
+  'All cookies use Secure/HttpOnly/SameSite': '所有 Cookie 均设置了 Secure、HttpOnly 和 SameSite',
+  'DNSSEC enabled': '已启用 DNSSEC',
+  'DNSSEC not enabled': '未启用 DNSSEC',
+  'No web application firewall detected': '未检测到 Web 应用防火墙',
+  'No HSTS header': '未设置 HSTS 响应头',
+  'HSTS missing includeSubDomains': 'HSTS 缺少 includeSubDomains',
+  'HSTS missing preload directive': 'HSTS 缺少 preload 指令',
+  'HSTS preload compatible': '符合 HSTS 预加载要求',
+  'No SPF record found': '未发现 SPF 记录',
+  'SPF record published': '已发布 SPF 记录',
+  'No DMARC record found': '未发现 DMARC 记录',
+  'DMARC policy: reject': 'DMARC 策略：拒绝',
+  'DMARC policy: quarantine': 'DMARC 策略：隔离',
+  'DKIM key found': '已发现 DKIM 密钥',
+  'HTTP requests are redirected to HTTPS': 'HTTP 请求会重定向到 HTTPS',
+  'Site does not enforce HTTPS': '站点未强制使用 HTTPS',
+  'No security.txt published': '未发布 security.txt',
+  'security.txt found': '已发现 security.txt',
+  'security.txt not PGP signed': 'security.txt 未使用 PGP 签名',
+  'Social share metadata complete': '社交分享元数据完整',
+  'SSL certificate invalid': 'SSL 证书无效',
+  'SSL certificate valid': 'SSL 证书有效',
+  'SSL certificate expired': 'SSL 证书已过期',
+  'SSL certificate expiring within a week': 'SSL 证书将在一周内到期',
+  'SSL certificate expiring soon': 'SSL 证书即将到期',
+  'Listed by Google Safe Browsing': '已被 Google 安全浏览列出',
+  'Listed on URLhaus malware feed': '已被 URLhaus 恶意软件源列出',
+  'Listed on PhishTank': '已被 PhishTank 列出',
+  'No threat feed matches': '未命中威胁情报源',
+  'TLS 1.2 in use, consider enabling TLS 1.3': '当前使用 TLS 1.2，建议启用 TLS 1.3',
+  'TLS 1.3 negotiated': '已协商使用 TLS 1.3',
+  'No forward secrecy in negotiated cipher': '协商的密码套件不支持前向保密',
+  'OCSP stapling not enabled': '未启用 OCSP 装订',
+  'HTTP/2 negotiated via ALPN': '已通过 ALPN 协商 HTTP/2',
+  'Root SPF record is overly permissive': '根域名 SPF 记录过于宽松',
+  'Domain registration expired': '域名注册已过期',
+  'Domain expires within a week': '域名将在一周内到期',
+  'Domain expires within a month': '域名将在一个月内到期',
+  'Domain registration is valid': '域名注册状态有效',
+  success: '成功',
+  loading: '加载中',
+  skipped: '已跳过',
+  error: '失败',
+  'timed-out': '已超时',
+  successful: '成功',
+  failed: '失败',
+  'timed out': '超时',
+  Critical: '严重',
+  Issues: '问题',
+  Warnings: '警告',
+  Informational: '提示',
+  Passes: '通过',
+  'Identify Infostealer infection data related to domains and emails':
+    '查询与域名和邮箱有关的信息窃取恶意软件数据',
+  'Analyzes the SSL configuration of a server and grades it': '分析服务器 SSL 配置并给出评级',
+  'Checks a URL against multiple antivirus engines': '使用多个反病毒引擎检查网址',
+  'Search engine for Internet-connected devices': '面向联网设备的搜索引擎',
+  'View previous versions of a site via the Internet Archive': '通过互联网档案馆查看网站历史版本',
+  'Scans a URL and provides information about the page': '扫描网址并提供页面相关信息',
+  'Checks a URL against blacklists and known threats': '根据黑名单和已知威胁检查网址',
+  'Run a WhoIs lookup on a domain': '查询域名 WHOIS 信息',
+  'View DNS records for a domain': '查看域名 DNS 记录',
+  'Check global DNS propagation across multiple servers': '检查 DNS 记录在全球多个服务器的传播情况',
+  'Lookup hosts associated with a domain': '查询与域名关联的主机',
+  'Checks the performance, accessibility and SEO of a page on mobile + desktop':
+    '检查页面在移动端和桌面端的性能、可访问性与 SEO',
+  'View the tech stack of a website': '查看网站使用的技术栈',
+  "DNS recon tool, to map out a domain from it's DNS records": '根据 DNS 记录绘制域名资产关系',
+  'View realtime BGP data for any ASN, Prefix or DNS': '查看 ASN、网段或 DNS 的实时 BGP 数据',
+  'View approx traffic and engagement stats for a website': '查看网站流量与互动情况估算',
+  'Check if a domain, IP or email is present on the top blacklists':
+    '检查域名、IP 或邮箱是否出现在主流黑名单中',
+  'View traffic source locations for a domain through Cloudflare':
+    '通过 Cloudflare 查看域名的流量来源地区',
+  'Assesses website security posture by analyzing various security headers and practices':
+    '通过安全响应头和最佳实践评估网站安全状态',
+  "Checks a website against Zscaler's dynamic risk scoring engine": '查询网站的动态风险评分',
+  'View shared human and machine generated threat intelligence': '查看人工与自动化共享威胁情报',
+  'Checks a website across 30+ blocklist engines and website reputation services':
+    '通过 30 多个拦截引擎和信誉服务检查网站',
+  "Checks if the site is in URLhaus's malware URL exchange":
+    '检查网站是否出现在 URLhaus 恶意网址库中',
+  'An interactive malware and web sandbox': '交互式恶意软件与网页沙箱',
+  Online: '在线',
+  Offline: '离线',
+  'ⓘ Present': 'ⓘ 已提供',
+  'ⓘ Not Present (may impact visitor privacy)': 'ⓘ 未提供（可能影响访客隐私）',
+  '✅ Trusted': '✅ 受信任',
+  Untrusted: '不受信任',
+  Renegotiation: '重新协商',
+  'Fallback SCSV (downgrade protection)': 'Fallback SCSV（降级保护）',
+  'Certificate Transparency': '证书透明度',
+  'HTTP -> HTTPS Forwarding': 'HTTP → HTTPS 跳转',
+  'ChaCha20 Preferred': '优先使用 ChaCha20',
+  'AEAD Cipher Support': '支持 AEAD 密码套件',
+  'Legacy CBC Cipher Support': '支持旧版 CBC 密码套件',
+  'TLS Compression': 'TLS 压缩',
+  'Static DH Key Reuse': '静态 DH 密钥复用',
+  'Weak DH Primes': '弱 DH 素数',
+  'Static ECDH Parameter Reuse': '静态 ECDH 参数复用',
+  '⚠️ Vulnerable': '⚠️ 存在风险',
+  '✅ With all browsers': '✅ 支持所有浏览器',
+  '⚠️ With most modern browsers': '⚠️ 支持大多数现代浏览器',
+  '⚠️ Limited': '⚠️ 有限支持',
+  '✅ Not supported': '✅ 不支持',
+  '⚠️ Insecure client-initiated': '⚠️ 允许不安全的客户端发起重新协商',
+  '✅ Supported': '✅ 支持',
+  '⚠️ IDs returned, not resumed': '⚠️ 返回会话 ID，但未恢复',
+  '❌ Not enabled': '❌ 未启用',
+  '⚠️ Supported (CRIME risk)': '⚠️ 已启用（存在 CRIME 风险）',
+  '✅ Disabled': '✅ 已禁用',
+  Cipher: '密码套件',
+  'Key Exchange': '密钥交换',
+  'Key Exchange Strength': '密钥交换强度',
+  'DH Strength': 'DH 强度',
+  'Key Algorithm': '密钥算法',
+  'Key Size': '密钥长度',
+  'Signature Algorithm': '签名算法',
+  Attempts: '尝试次数',
+};
+
+export interface LocalizedDoc {
+  title: string;
+  description: string;
+  use: string;
+}
+
+export const chineseDocs: Record<string, LocalizedDoc> = {
+  'get-ip': {
+    title: 'IP 信息',
+    description: '查询域名对应的 IP 地址，并确认目标服务器在网络中的地址。',
+    use: 'IP 是后续定位、端口探测、主机关系分析和基础设施调查的起点。',
+  },
+  ssl: {
+    title: 'SSL 证书链',
+    description: '读取目标站点提供的证书、签发者、有效期和信任状态。',
+    use: '用于验证 HTTPS 身份、发现证书配置问题，并了解关联域名和组织信息。',
+  },
+  dns: {
+    title: 'DNS 记录',
+    description: '查询 A、AAAA、MX、NS、CNAME、TXT 等域名系统记录。',
+    use: '用于理解网站基础设施、邮件服务、托管关系及可能暴露的配置。',
+  },
+  cookies: {
+    title: 'Cookie',
+    description: '检查服务器响应与浏览器脚本设置的 Cookie 及其安全属性。',
+    use: '可判断会话、跟踪机制，以及 Secure、HttpOnly、SameSite 等安全配置。',
+  },
+  'robots-txt': {
+    title: '爬虫规则',
+    description: '读取 robots.txt 中针对搜索引擎和自动化爬虫的访问规则。',
+    use: '可了解站点索引策略，并发现未在导航中公开的路径。',
+  },
+  headers: {
+    title: 'HTTP 响应头',
+    description: '提取服务器返回的缓存、内容类型、技术标识和安全相关响应头。',
+    use: '用于分析服务器技术、缓存策略、安全控制和可能泄露的信息。',
+  },
+  quality: {
+    title: '网站质量指标',
+    description: '通过 Lighthouse 评估性能、可访问性、最佳实践和 SEO。',
+    use: '用于快速定位网页质量、用户体验和搜索优化方面的问题。',
+  },
+  location: {
+    title: '服务器位置',
+    description: '根据 IP 地理数据库估算服务器所在城市、国家、网络和时区。',
+    use: '用于了解托管区域、数据驻留、网络延迟和服务提供商。',
+  },
+  hosts: {
+    title: '关联主机',
+    description: '列出与目标 IP 或域名关联的主机名和域名。',
+    use: '用于扩展攻击面地图，发现相关服务、测试环境或历史资产。',
+  },
+  redirects: {
+    title: '重定向链',
+    description: '逐步记录目标请求经过的 HTTP 重定向。',
+    use: '用于发现过长跳转、错误目标，以及 HTTP 到 HTTPS 的升级策略。',
+  },
+  'txt-records': {
+    title: 'TXT 记录',
+    description: '读取域名发布的 TXT 文本记录。',
+    use: '常用于检查 SPF、站点验证信息及可能暴露的基础设施配置。',
+  },
+  status: {
+    title: '服务器状态',
+    description: '测试目标是否可访问，并记录响应状态和耗时。',
+    use: '用于快速判断可用性、延迟和异常响应。',
+  },
+  ports: {
+    title: '开放端口',
+    description: '探测目标主机上一组常见 TCP 端口。',
+    use: '用于了解对外暴露的服务，并识别不必要或高风险的网络入口。',
+  },
+  'trace-route': {
+    title: '路由追踪',
+    description: '记录当前服务器到目标主机之间的网络跳点。',
+    use: '用于诊断路由、延迟和网络边界。',
+  },
+  carbon: {
+    title: '碳足迹',
+    description: '根据页面传输大小估算一次加载的能耗和二氧化碳排放。',
+    use: '用于比较页面体积和环境影响，辅助前端性能优化。',
+  },
+  'server-info': {
+    title: '服务器信息',
+    description: '汇总组织、ISP、ASN、操作系统、端口和位置等主机信息。',
+    use: '用于理解目标的托管环境和网络归属。',
+  },
+  vulnerabilities: {
+    title: '已知漏洞',
+    description: '显示威胁情报服务报告的 CVE 和已知暴露问题。',
+    use: '用于确定补丁和服务加固的优先级，结果仍需人工复核。',
+  },
+  domain: {
+    title: 'WHOIS 查询',
+    description: '查询域名注册商、注册日期、到期日期和注册局标识。',
+    use: '用于核实域名归属、生命周期和注册状态。',
+  },
+  whois: {
+    title: '域名信息',
+    description: '整理 WHOIS 或 RDAP 返回的域名注册资料。',
+    use: '用于调查域名历史、注册时间、到期风险和名称服务器。',
+  },
+  dnssec: {
+    title: 'DNS 安全扩展',
+    description: '检查 DNSKEY、DS、RRSIG 等 DNSSEC 记录。',
+    use: '用于确认 DNS 响应是否具备签名验证能力，以降低伪造和缓存投毒风险。',
+  },
+  hsts: {
+    title: 'HTTP 严格传输安全',
+    description: '检查 Strict-Transport-Security 响应头及预加载兼容性。',
+    use: '用于确认浏览器会强制使用 HTTPS，并保护子域名。',
+  },
+  'dns-server': {
+    title: 'DNS 服务器',
+    description: '查询目标域名的权威名称服务器及其地址。',
+    use: '用于了解 DNS 托管结构和冗余配置。',
+  },
+  'tech-stack': {
+    title: '技术栈',
+    description: '识别网页使用的框架、服务器、分析工具和第三方服务。',
+    use: '用于技术调研、资产盘点和攻击面分析。',
+  },
+  sitemap: {
+    title: '站点页面',
+    description: '读取站点地图及其页面、更新时间和优先级。',
+    use: '用于了解网站结构、公开页面范围和搜索引擎索引策略。',
+  },
+  'security-txt': {
+    title: 'Security.txt',
+    description: '检查标准安全披露联系文件是否存在并有效。',
+    use: '便于安全研究人员找到正确的漏洞报告渠道。',
+  },
+  'linked-pages': {
+    title: '页面链接',
+    description: '提取目标页面中的内部链接和外部链接。',
+    use: '用于理解站点结构、依赖关系和对外连接。',
+  },
+  'social-tags': {
+    title: '社交分享标签',
+    description: '检查 Open Graph、Twitter 卡片和常用页面元数据。',
+    use: '用于优化搜索结果与社交平台分享预览。',
+  },
+  'mail-config': {
+    title: '邮件配置',
+    description: '检查 MX、SPF、DKIM、DMARC 和 BIMI 等邮件相关配置。',
+    use: '用于评估邮件投递、域名伪造和钓鱼防护能力。',
+  },
+  firewall: {
+    title: '防火墙检测',
+    description: '根据响应特征识别常见 Web 应用防火墙。',
+    use: '用于了解目标是否部署了针对恶意请求的边界防护。',
+  },
+  'http-security': {
+    title: 'HTTP 安全功能',
+    description: '汇总 CSP、HSTS、Frame、Referrer、Permissions 等安全响应头。',
+    use: '用于快速发现浏览器侧安全策略缺失。',
+  },
+  archives: {
+    title: '历史归档',
+    description: '通过 Wayback Machine 获取网站的历史快照统计。',
+    use: '用于了解站点演变，并查找已删除或修改的历史内容。',
+  },
+  rank: {
+    title: '全球排名',
+    description: '根据 Tranco 数据显示站点在热门网站中的相对排名。',
+    use: '用于粗略判断网站规模、流行度和历史趋势。',
+  },
+  'block-lists': {
+    title: '拦截名单检测',
+    description: '使用多个隐私、恶意软件和家长控制 DNS 服务测试目标是否被拦截。',
+    use: '用于了解域名信誉和在不同过滤服务中的可访问性。',
+  },
+  threats: {
+    title: '恶意软件与钓鱼检测',
+    description: '查询多个恶意软件、钓鱼和安全浏览情报源。',
+    use: '用于快速评估目标信誉；命中结果需要结合情报源进一步确认。',
+  },
+  'tls-connection': {
+    title: 'TLS 连接',
+    description: '执行真实 TLS 握手，显示协议、密码套件、ALPN 和证书信任状态。',
+    use: '用于确认客户端当前实际协商到的加密配置。',
+  },
+  'tls-security-audit': {
+    title: 'TLS 安全审计',
+    description: '基于 SSL Labs 报告汇总评级、协议、前向保密和历史漏洞。',
+    use: '用于快速识别弱 TLS 配置和已知风险。',
+  },
+  'tls-client-compat': {
+    title: 'TLS 客户端兼容性',
+    description: '模拟常见浏览器、系统和运行库与目标的 TLS 握手。',
+    use: '用于确认旧版或受限客户端是否仍能连接。',
+  },
+  screenshot: {
+    title: '网页截图',
+    description: '从扫描服务器所在网络访问目标并生成页面截图。',
+    use: '用于快速确认目标页面外观、地域差异或无头浏览器中的呈现结果。',
+  },
+  subdomains: {
+    title: '子域名',
+    description: '通过证书透明度日志和公开数据源发现目标域名下的子域名。',
+    use: '用于梳理公开攻击面，发现开发、测试、管理或历史服务。',
+  },
+};
+
+export const chineseAbout = [
+  'Web Check 是一款用于发现网站或主机信息的一站式工具。只需输入网址，它就会收集、整理并呈现多种公开数据，供你进一步分析。',
+  '报告会突出潜在攻击面、现有安全措施以及网站架构中的关联关系，也能帮助站点维护者优化服务器响应、重定向、Cookie 和 DNS 配置。',
+  '无论你是开发者、系统管理员、安全研究人员、渗透测试人员，还是希望了解网站底层技术，都可以将它作为日常工具的一部分。',
+];
+
+export const chineseFeatureIntro = [
+  '对网站或主机开展开源情报调查时，需要关注多个关键领域。下方逐项说明了这些检查，并提供继续研究所需的工具和资料。',
+  'Web Check 可以自动收集这些数据，但仍需要由你结合场景解释结果并作出判断。',
+];
+
+export const chineseSupportUs = [
+  'Web Check 可以不受限制地免费使用。',
+  '所有代码均为开源，你可以部署自己的实例，也可以在个人或商业场景中派生、修改和分发。',
+  "运行公共实例每月会产生费用。如果这个工具对你有帮助，可以考虑在 <a href='https://github.com/sponsors/Lissy93'>GitHub 上赞助项目</a>。每月 1 至 2 美元也能为持续维护提供很大帮助。",
+  "你也可以通过向 <a href='https://github.com/lissy93/web-check'>GitHub 仓库</a>提交或审查代码、在 Product Hunt 投票，或向其他人分享项目来提供帮助。",
+  '无需为此感到有压力；这个项目会一直保持免费和开源，我们也会尽力维持公共实例可用。',
+];
+
+export const chineseFairUse = [
+  '请负责任地使用本工具。不要扫描未经授权的主机，也不要将它用于攻击或中断服务。',
+  '为防止滥用，请求可能受到限流。如果需要更高额度，请部署自己的实例。',
+  '公共服务不保证正常运行时间或可用性。如有稳定性要求，请部署自己的实例。',
+  '请合理使用。过量请求会迅速耗尽 Serverless 配额，影响其他用户。',
+];
+
+const LanguageContext = createContext<{
+  language: Language;
+  setLanguage: (language: Language) => void;
+  t: (key: MessageKey, values?: Record<string, string | number>) => string;
+}>({
+  language: 'en',
+  setLanguage: () => undefined,
+  t: (key) => messages.en[key],
+});
+
+const detectLanguage = (): Language => {
+  if (
+    typeof document !== 'undefined' &&
+    document.documentElement.lang.toLowerCase().startsWith('zh')
+  ) {
+    return 'zh-CN';
+  }
+  if (typeof navigator !== 'undefined' && navigator.language.toLowerCase().startsWith('zh')) {
+    return 'zh-CN';
+  }
+  return 'en';
+};
+
+const interpolate = (message: string, values?: Record<string, string | number>) =>
+  Object.entries(values || {}).reduce(
+    (result, [key, value]) => result.split(`{${key}}`).join(String(value)),
+    message,
+  );
+
+export const LanguageProvider = ({ children }: { children: ReactNode }) => {
+  const [language, setLanguageState] = useState<Language>(detectLanguage);
+
+  const setLanguage = useCallback((next: Language) => {
+    setLanguageState(next);
+    document.documentElement.lang = next;
+    window.localStorage.setItem(STORAGE_KEY, next);
+    window.dispatchEvent(new CustomEvent('web-check-language-change', { detail: next }));
+  }, []);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === 'en' || stored === 'zh-CN') setLanguageState(stored);
+
+    const onLanguageChange = (event: Event) => {
+      const next = (event as CustomEvent<Language>).detail;
+      if (next === 'en' || next === 'zh-CN') setLanguageState(next);
+    };
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY && (event.newValue === 'en' || event.newValue === 'zh-CN')) {
+        setLanguageState(event.newValue);
+      }
+    };
+    window.addEventListener('web-check-language-change', onLanguageChange);
+    window.addEventListener('storage', onStorage);
+    return () => {
+      window.removeEventListener('web-check-language-change', onLanguageChange);
+      window.removeEventListener('storage', onStorage);
+    };
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+  }, [language]);
+
+  const t = useCallback(
+    (key: MessageKey, values?: Record<string, string | number>) =>
+      interpolate(messages[language][key], values),
+    [language],
+  );
+
+  const value = useMemo(() => ({ language, setLanguage, t }), [language, setLanguage, t]);
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+};
+
+export const useLanguage = () => useContext(LanguageContext);
+
+export const localizeCardTitle = (id: string, fallback: string, language: Language) =>
+  language === 'zh-CN' ? cardTitles[id] || fallback : fallback;
+
+export const localizeText = (text: unknown, language: Language): string => {
+  const value = String(text ?? '');
+  if (language !== 'zh-CN') return value;
+  const direct = chineseText[value];
+  if (direct) return direct;
+
+  const dynamic: Array<[RegExp, (match: RegExpMatchArray) => string]> = [
+    [/^First (\d+)$/, (m) => `前 ${m[1]} 项`],
+    [/^(\d+) records$/, (m) => `${m[1]} 条记录`],
+    [/^Record #(\d+)$/, (m) => `记录 #${m[1]}`],
+    [/^(.+) - Present\?$/, (m) => `${m[1]} - 是否存在`],
+    [/^Blocked by (\d+) DNS resolver\(s\)$/, (m) => `被 ${m[1]} 个 DNS 解析服务拦截`],
+    [/^Long redirect chain: (\d+) hops$/, (m) => `重定向链过长：${m[1]} 跳`],
+    [/^(\d+) redirect hop\(s\)$/, (m) => `${m[1]} 次重定向`],
+    [/^Site responded with (\d+)$/, (m) => `站点响应状态码 ${m[1]}`],
+    [/^Response time over (\d+)ms$/, (m) => `响应时间超过 ${m[1]} 毫秒`],
+    [/^SSL Labs grade (.+)$/, (m) => `SSL Labs 评级 ${m[1]}`],
+    [/^Missing (.+)$/, (m) => `缺少 ${m[1]}`],
+    [/^(.+) set$/, (m) => `已设置 ${m[1]}`],
+    [/^Port (\d+) open: (.+)$/, (m) => `端口 ${m[1]} 开放：${m[2]}`],
+    [/^Cookie "(.+)" missing Secure flag$/, (m) => `Cookie“${m[1]}”缺少 Secure 标志`],
+    [/^Cookie "(.+)" missing HttpOnly flag$/, (m) => `Cookie“${m[1]}”缺少 HttpOnly 标志`],
+    [/^Cookie "(.+)" missing SameSite flag$/, (m) => `Cookie“${m[1]}”缺少 SameSite 标志`],
+    [/^WAF detected: (.+)$/, (m) => `检测到 WAF：${m[1]}`],
+    [/^Server discloses (.+)$/, (m) => `服务器暴露 ${m[1]}`],
+    [/^Missing social tags: (\d+)$/, (m) => `缺少 ${m[1]} 个社交分享标签`],
+    [/^Outdated TLS protocol negotiated: (.+)$/, (m) => `协商了过时的 TLS 协议：${m[1]}`],
+    [/^Shodan reports (\d+) CVE\(s\) on this host$/, (m) => `Shodan 报告该主机存在 ${m[1]} 个 CVE`],
+  ];
+  for (const [pattern, translate] of dynamic) {
+    const match = value.match(pattern);
+    if (match) return translate(match);
+  }
+  return value;
+};
+
+export const localizeDoc = <
+  T extends { id: string; title: string; description: string; use: string },
+>(
+  doc: T,
+  language: Language,
+): T => {
+  if (language !== 'zh-CN' || !chineseDocs[doc.id]) return doc;
+  return { ...doc, ...chineseDocs[doc.id] };
+};

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,8 +1,11 @@
 import { BrowserRouter } from 'react-router';
 import App from './App.tsx';
+import { LanguageProvider } from './i18n.tsx';
 
 export default () => (
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
+  <LanguageProvider>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </LanguageProvider>
 );

--- a/src/client/views/About.tsx
+++ b/src/client/views/About.tsx
@@ -10,6 +10,14 @@ import Button from 'client/components/Form/Button';
 import AdditionalResources from 'client/components/misc/AdditionalResources';
 import { StyledCard } from 'client/components/Form/Card';
 import docs, { about, featureIntro, license, fairUse, supportUs } from 'client/utils/docs';
+import {
+  chineseAbout,
+  chineseFairUse,
+  chineseFeatureIntro,
+  chineseSupportUs,
+  localizeDoc,
+  useLanguage,
+} from 'client/i18n';
 
 const AboutContainer = styled.div`
 width: 95vw;
@@ -128,7 +136,14 @@ const makeAnchor = (title: string): string =>
     .replace(/\s+/g, '-');
 
 const About = (): JSX.Element => {
+  const { language, t } = useLanguage();
   const location = useLocation();
+  const zh = language === 'zh-CN';
+  const z = (english: string, chinese: string) => (zh ? chinese : english);
+  const aboutCopy = zh ? chineseAbout : about;
+  const featureCopy = zh ? chineseFeatureIntro : featureIntro;
+  const supportCopy = zh ? chineseSupportUs : supportUs;
+  const fairUseCopy = zh ? chineseFairUse : fairUse;
 
   useEffect(() => {
     // Scroll to hash fragment if present
@@ -149,22 +164,22 @@ const About = (): JSX.Element => {
         <Nav>
           <HeaderLinkContainer>
             <a target="_blank" rel="noreferrer" href="https://github.com/lissy93/web-check">
-              <Button>View on GitHub</Button>
+              <Button>{t('viewGithub')}</Button>
             </a>
           </HeaderLinkContainer>
         </Nav>
 
         <Heading as="h2" size="medium" color={colors.primary}>
-          Intro
+          {z('Intro', '项目介绍')}
         </Heading>
         <Section>
-          {about.map((para, index: number) => (
+          {aboutCopy.map((para, index: number) => (
             <p key={index}>{para}</p>
           ))}
           <hr />
           <SponsorshipContainer>
             <p>
-              Web-Check is kindly sponsored by{' '}
+              {z('Web-Check is kindly sponsored by', 'Web Check 由以下伙伴赞助')}{' '}
               <a
                 target="_blank"
                 rel="noreferrer"
@@ -173,7 +188,7 @@ const About = (): JSX.Element => {
                 Terminal Trove
               </a>
               <br />
-              The $HOME of all things in the terminal.
+              {z('The $HOME of all things in the terminal.', '发现优秀终端工具的聚合站。')}
               <br />
               <small>
                 <a
@@ -181,7 +196,10 @@ const About = (): JSX.Element => {
                   rel="noreferrer"
                   href="https://terminaltrove.com/newsletter?utm_campaign=github&utm_medium=referral&utm_content=web-check&utm_source=wcgh"
                 >
-                  Find your next CLI / TUI tool, and get updates to your inbox
+                  {z(
+                    'Find your next CLI / TUI tool, and get updates to your inbox',
+                    '发现新的 CLI / TUI 工具，并通过邮件获取更新',
+                  )}
                 </a>
               </small>
             </p>
@@ -199,161 +217,194 @@ const About = (): JSX.Element => {
           </SponsorshipContainer>
           <hr />
           <p>
-            Web-Check is developed and maintained by{' '}
+            {z('Web-Check is developed and maintained by', 'Web Check 的开发与维护者是')}{' '}
             <a target="_blank" rel="noreferrer" href="https://aliciasykes.com">
               Alicia Sykes
             </a>
-            . It's licensed under the{' '}
+            {zh ? '。' : '. '}
+            {z("It's licensed under the", '项目采用')}{' '}
             <a
               target="_blank"
               rel="noreferrer"
               href="https://github.com/Lissy93/web-check/blob/master/LICENSE"
             >
-              MIT license
+              {z('MIT license', 'MIT 许可证')}
             </a>
-            , and is completely free to use, modify and distribute in both personal and commercial
-            settings.
+            {z(
+              ', and is completely free to use, modify and distribute in both personal and commercial settings.',
+              '，可在个人和商业场景中免费使用、修改和分发。',
+            )}
             <br />
-            Source code and self-hosting docs are available on{' '}
+            {z('Source code and self-hosting docs are available on', '源代码和自托管文档位于')}{' '}
             <a target="_blank" rel="noreferrer" href="https://github.com/lissy93/web-check">
               GitHub
             </a>
-            . If you've found this service useful, consider{' '}
+            {zh ? '。' : '. '}
+            {z("If you've found this service useful, consider", '如果本服务对你有帮助，可以考虑')}
+            {zh ? '' : ' '}
             <a target="_blank" rel="noreferrer" href="https://github.com/sponsors/Lissy93">
-              sponsoring me
-            </a>{' '}
-            from $1/month, to help with the ongoing hosting and development costs.
+              {z('sponsoring me', '赞助项目')}
+            </a>
+            {zh ? '' : ' '}
+            {z(
+              'from $1/month, to help with the ongoing hosting and development costs.',
+              '，每月 1 美元即可帮助承担持续的托管和开发成本。',
+            )}
           </p>
         </Section>
 
         <Heading as="h2" size="medium" color={colors.primary}>
-          Features
+          {z('Features', '功能说明')}
         </Heading>
         <Section>
-          {featureIntro.map((fi: string, i: number) => (
+          {featureCopy.map((fi: string, i: number) => (
             <p key={i}>{fi}</p>
           ))}
           <div className="contents">
             <Heading as="h3" size="small" id="#feature-contents" color={colors.primary}>
-              Contents
+              {z('Contents', '目录')}
             </Heading>
             <ul>
               {docs.map((section, index: number) => (
                 <li key={index}>
                   <b>{index + 1}</b>
-                  <a href={`#${makeAnchor(section.title)}`}>{section.title}</a>
+                  <a href={`#${makeAnchor(section.title)}`}>
+                    {localizeDoc(section, language).title}
+                  </a>
                 </li>
               ))}
             </ul>
             <hr />
           </div>
-          {docs.map((section, sectionIndex: number) => (
-            <section key={section.title}>
-              {sectionIndex > 0 && <hr />}
-              <Heading as="h3" size="small" id={makeAnchor(section.title)} color={colors.primary}>
-                {section.title}
-              </Heading>
-              {section.screenshot && (
-                <figure className="example-screenshot">
-                  <img
-                    className="screenshot"
-                    src={section.screenshot}
-                    alt={`Example Screenshot ${section.title}`}
-                  />
-                  <figcaption>
-                    Fig.{sectionIndex + 1} - Example of {section.title}
-                  </figcaption>
-                </figure>
-              )}
-              {section.description && (
-                <>
-                  <Heading as="h4" size="small">
-                    Description
-                  </Heading>
-                  <p>{section.description}</p>
-                </>
-              )}
-              {section.use && (
-                <>
-                  <Heading as="h4" size="small">
-                    Use Cases
-                  </Heading>
-                  <p>{section.use}</p>
-                </>
-              )}
-              {section.resources && section.resources.length > 0 && (
-                <>
-                  <Heading as="h4" size="small">
-                    Useful Links
-                  </Heading>
-                  <ul>
-                    {section.resources.map(
-                      (link: string | { title: string; link: string }, linkIndx: number) =>
-                        typeof link === 'string' ? (
-                          <li key={`link-${linkIndx}`} id={`link-${linkIndx}`}>
-                            <a target="_blank" rel="noreferrer" href={link}>
-                              {link}
-                            </a>
-                          </li>
-                        ) : (
-                          <li key={`link-${linkIndx}`} id={`link-${linkIndx}`}>
-                            <a target="_blank" rel="noreferrer" href={link.link}>
-                              {link.title}
-                            </a>
-                          </li>
-                        ),
-                    )}
-                  </ul>
-                </>
-              )}
-            </section>
-          ))}
+          {docs.map((sourceSection, sectionIndex: number) => {
+            const section = localizeDoc(sourceSection, language);
+            return (
+              <section key={section.title}>
+                {sectionIndex > 0 && <hr />}
+                <Heading
+                  as="h3"
+                  size="small"
+                  id={makeAnchor(sourceSection.title)}
+                  color={colors.primary}
+                >
+                  {section.title}
+                </Heading>
+                {section.screenshot && (
+                  <figure className="example-screenshot">
+                    <img
+                      className="screenshot"
+                      src={section.screenshot}
+                      alt={z(`Example Screenshot ${section.title}`, `${section.title} 示例截图`)}
+                    />
+                    <figcaption>
+                      {z(
+                        `Fig.${sectionIndex + 1} - Example of ${section.title}`,
+                        `图 ${sectionIndex + 1} - ${section.title} 示例`,
+                      )}
+                    </figcaption>
+                  </figure>
+                )}
+                {section.description && (
+                  <>
+                    <Heading as="h4" size="small">
+                      {z('Description', '说明')}
+                    </Heading>
+                    <p>{section.description}</p>
+                  </>
+                )}
+                {section.use && (
+                  <>
+                    <Heading as="h4" size="small">
+                      {z('Use Cases', '应用场景')}
+                    </Heading>
+                    <p>{section.use}</p>
+                  </>
+                )}
+                {section.resources && section.resources.length > 0 && (
+                  <>
+                    <Heading as="h4" size="small">
+                      {z('Useful Links', '相关链接')}
+                    </Heading>
+                    <ul>
+                      {section.resources.map(
+                        (link: string | { title: string; link: string }, linkIndx: number) =>
+                          typeof link === 'string' ? (
+                            <li key={`link-${linkIndx}`} id={`link-${linkIndx}`}>
+                              <a target="_blank" rel="noreferrer" href={link}>
+                                {link}
+                              </a>
+                            </li>
+                          ) : (
+                            <li key={`link-${linkIndx}`} id={`link-${linkIndx}`}>
+                              <a target="_blank" rel="noreferrer" href={link.link}>
+                                {link.title}
+                              </a>
+                            </li>
+                          ),
+                      )}
+                    </ul>
+                  </>
+                )}
+              </section>
+            );
+          })}
         </Section>
 
         <Heading as="h2" size="medium" color={colors.primary}>
-          Deploy your own Instance
+          {z('Deploy your own Instance', '部署自己的实例')}
         </Heading>
         <Section>
-          <p>Web-Check is designed to be easily self-hosted.</p>
+          <p>
+            {z(
+              'Web-Check is designed to be easily self-hosted.',
+              'Web Check 支持便捷的自托管部署。',
+            )}
+          </p>
           <Heading as="h3" size="small" color={colors.primary}>
-            Option #1 - Netlify
+            {z('Option #1 - Netlify', '方式 #1 - Netlify')}
           </Heading>
-          <p>Click the button below to deploy to Netlify</p>
+          <p>{z('Click the button below to deploy to Netlify', '点击下方按钮部署到 Netlify')}</p>
           <a
             target="_blank"
             rel="noreferrer"
             href="https://app.netlify.com/start/deploy?repository=https://github.com/lissy93/web-check"
           >
-            <img src="https://www.netlify.com/img/deploy/button.svg" alt="Deploy to Netlify" />
+            <img
+              src="https://www.netlify.com/img/deploy/button.svg"
+              alt={z('Deploy to Netlify', '部署到 Netlify')}
+            />
           </a>
 
           <Heading as="h3" size="small" color={colors.primary}>
-            Option #2 - Vercel
+            {z('Option #2 - Vercel', '方式 #2 - Vercel')}
           </Heading>
-          <p>Click the button below to deploy to Vercel</p>
+          <p>{z('Click the button below to deploy to Vercel', '点击下方按钮部署到 Vercel')}</p>
           <a
             target="_blank"
             rel="noreferrer"
             href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flissy93%2Fweb-check&project-name=web-check&repository-name=web-check-fork&demo-title=Web-Check%20Demo&demo-description=Check%20out%20web-check.xyz%20to%20see%20a%20live%20demo%20of%20this%20application%20running.&demo-url=https%3A%2F%2Fweb-check.xyz&demo-image=https%3A%2F%2Fraw.githubusercontent.com%2FLissy93%2Fweb-check%2Fmaster%2F.github%2Fscreenshots%2Fweb-check-screenshot10.png"
           >
-            <img src="https://vercel.com/button" alt="Deploy with Vercel" />
+            <img
+              src="https://vercel.com/button"
+              alt={z('Deploy with Vercel', '使用 Vercel 部署')}
+            />
           </a>
 
           <Heading as="h3" size="small" color={colors.primary}>
-            Option #3 - Docker
+            {z('Option #3 - Docker', '方式 #3 - Docker')}
           </Heading>
           <p>
-            A Docker container is published to{' '}
+            {z('A Docker container is published to', 'Docker 镜像已发布到')}{' '}
             <a target="_blank" rel="noreferrer" href="https://hub.docker.com/r/lissy93/web-check">
               DockerHub
             </a>
             <br />
-            Run this command, then open <code>localhost:3000</code>
-            <pre>docker run -p 3000:3000 lissy93/web-check</pre>
+            {z('Run this command, then open', '运行以下命令，然后打开')} <code>localhost:3000</code>
           </p>
+          <pre>docker run -p 3000:3000 lissy93/web-check</pre>
 
           <Heading as="h3" size="small" color={colors.primary}>
-            Option #4 - Manual
+            {z('Option #4 - Manual', '方式 #4 - 手动部署')}
           </Heading>
           <pre>
             git clone https://github.com/Lissy93/web-check.git
@@ -369,22 +420,26 @@ const About = (): JSX.Element => {
           </pre>
 
           <Heading as="h3" size="small" color={colors.primary}>
-            Further Docs
+            {z('Further Docs', '更多文档')}
           </Heading>
           <p>
-            More detailed installation and setup instructions can be found in the GitHub repository
-            -{' '}
+            {z(
+              'More detailed installation and setup instructions can be found in the GitHub repository -',
+              '更详细的安装与配置说明请查看 GitHub 仓库：',
+            )}{' '}
             <a target="_blank" rel="noreferrer" href="https://github.com/lissy93/web-check#readme">
               github.com/lissy93/web-check
             </a>
           </p>
 
           <Heading as="h3" size="small" color={colors.primary}>
-            Configuring
+            {z('Configuring', '配置')}
           </Heading>
           <p>
-            There are some optional environmental variables you can specify to give you access to
-            some additional Web-Checks. See the README for full list of options.
+            {z(
+              'There are some optional environmental variables you can specify to give you access to some additional Web-Checks. See the README for full list of options.',
+              '可通过可选环境变量启用更多检查能力，完整配置项请查看 README。',
+            )}
           </p>
 
           <ul>
@@ -395,63 +450,68 @@ const About = (): JSX.Element => {
                 rel="noreferrer"
                 href="https://developers.google.com/speed/docs/insights/v5/get-started"
               >
-                A Google API key
+                {z('A Google API key', 'Google API 密钥')}
               </a>
               <i>
                 {' '}
-                With the PageSpeed Insights API enabled, used to return quality metrics for a site
+                {z(
+                  'With the PageSpeed Insights API enabled, used to return quality metrics for a site',
+                  '启用 PageSpeed Insights API 后，用于返回网站质量指标',
+                )}
               </i>
             </li>
             <li>
               <code>REACT_APP_SHODAN_API_KEY</code>:{' '}
               <a target="_blank" rel="noreferrer" href="https://account.shodan.io/">
-                A Shodan API key
+                {z('A Shodan API key', 'Shodan API 密钥')}
               </a>
-              <i> To show associated hosts for a domain</i>
+              <i>{z(' To show associated hosts for a domain', ' 用于显示域名关联主机')}</i>
             </li>
             <li>
               <code>REACT_APP_WHO_API_KEY</code>:{' '}
               <a target="_blank" rel="noreferrer" href="https://whoapi.com/">
-                A WhoAPI key
+                {z('A WhoAPI key', 'WhoAPI 密钥')}
               </a>
-              <i> Allows for more comprehensive WhoIs records</i>
+              <i>
+                {z(' Allows for more comprehensive WhoIs records', ' 用于获取更完整的 WHOIS 记录')}
+              </i>
             </li>
           </ul>
         </Section>
 
         <Heading as="h2" size="medium" color={colors.primary}>
-          API Documentation
+          {z('API Documentation', 'API 文档')}
         </Heading>
         <Section>
-          <p>// Coming soon...</p>
+          <p>{z('// Coming soon...', '// 即将推出...')}</p>
         </Section>
 
         <Heading as="h2" size="medium" color={colors.primary}>
-          Additional Resources
+          {z('Additional Resources', '更多资源')}
         </Heading>
         <AdditionalResources />
 
         <Heading as="h2" size="medium" color={colors.primary}>
-          Support Us
+          {z('Support Us', '支持我们')}
         </Heading>
         <Section>
-          {supportUs.map((para) => (
-            <p dangerouslySetInnerHTML={{ __html: para }} />
+          {supportCopy.map((para, index) => (
+            <p key={index} dangerouslySetInnerHTML={{ __html: para }} />
           ))}
         </Section>
 
         <Heading as="h2" size="medium" color={colors.primary}>
-          Terms & Info
+          {z('Terms & Info', '条款与信息')}
         </Heading>
         <Section>
           <Heading as="h3" size="small" color={colors.primary}>
-            License
+            {z('License', '许可证')}
           </Heading>
           <b>
             <a target="_blank" rel="noreferrer" href="https://github.com/lissy93/web-check">
               Web-Check
             </a>{' '}
-            is distributed under the MIT license, ©{' '}
+            {z('is distributed under the MIT license, ©', '采用 MIT 许可证发布，©')}{' '}
             <a target="_blank" rel="noreferrer" href="https://aliciasykes.com">
               Alicia Sykes
             </a>{' '}
@@ -459,7 +519,7 @@ const About = (): JSX.Element => {
           </b>
           <br />
           <small>
-            For more info, see{' '}
+            {z('For more info, see', '更多信息请参阅')}{' '}
             <a target="_blank" rel="noreferrer" href="https://tldrlegal.com/license/mit-license">
               TLDR Legal → MIT
             </a>
@@ -467,26 +527,28 @@ const About = (): JSX.Element => {
           <pre>{license}</pre>
           <hr />
           <Heading as="h3" size="small" color={colors.primary}>
-            Fair Use
+            {z('Fair Use', '合理使用')}
           </Heading>
           <ul>
-            {fairUse.map((para) => (
-              <li>{para}</li>
+            {fairUseCopy.map((para, index) => (
+              <li key={index}>{para}</li>
             ))}
           </ul>
           <hr />
           <Heading as="h3" size="small" color={colors.primary}>
-            Privacy
+            {z('Privacy', '隐私')}
           </Heading>
           <p>
-            Analytics are used on the demo instance (via a self-hosted Plausible instance), this
-            only records the URL you visited but no personal data. There's also some basic error
-            logging (via a self-hosted GlitchTip instance), this is only used to help me fix bugs.
+            {z(
+              "Analytics are used on the demo instance (via a self-hosted Plausible instance), this only records the URL you visited but no personal data. There's also some basic error logging (via a self-hosted GlitchTip instance), this is only used to help me fix bugs.",
+              '演示实例使用自托管 Plausible 进行访问统计，只记录访问的网址，不记录个人数据；同时使用自托管 GlitchTip 收集基础错误信息，仅用于修复问题。',
+            )}
             <br />
             <br />
-            Neither your IP address, browser/OS/hardware info, nor any other data will ever be
-            collected or logged. (You may verify this yourself, either by inspecting the source code
-            or the using developer tools)
+            {z(
+              'Neither your IP address, browser/OS/hardware info, nor any other data will ever be collected or logged. (You may verify this yourself, either by inspecting the source code or the using developer tools)',
+              '你的 IP 地址、浏览器、操作系统、硬件信息及其他个人数据都不会被收集或记录。你可以通过检查源代码或浏览器开发者工具自行验证。',
+            )}
           </p>
         </Section>
       </AboutContainer>

--- a/src/client/views/Home.tsx
+++ b/src/client/views/Home.tsx
@@ -8,10 +8,12 @@ import Button from 'client/components/Form/Button';
 import { StyledCard } from 'client/components/Form/Card';
 import Footer from 'client/components/misc/Footer';
 import FancyBackground from 'client/components/misc/FancyBackground';
+import LanguageSwitcher from 'client/components/misc/LanguageSwitcher';
 
 import docs from 'client/utils/docs';
 import colors from 'client/styles/colors';
 import { determineAddressType, normalizeAddress } from 'client/utils/address-type-checker';
+import { localizeDoc, useLanguage } from 'client/i18n';
 
 const HomeContainer = styled.section`
   display: flex;
@@ -24,6 +26,14 @@ const HomeContainer = styled.section`
   footer {
     z-index: 1;
   }
+`;
+
+const LanguagePosition = styled.div`
+  width: calc(100% - 2rem);
+  max-width: 60rem;
+  display: flex;
+  justify-content: flex-end;
+  z-index: 3;
 `;
 
 const UserInputMain = styled.form`
@@ -129,10 +139,12 @@ const makeAnchor = (title: string): string =>
     .replace(/\s+/g, '-');
 
 const Home = (): JSX.Element => {
-  const defaultPlaceholder = 'e.g. duck.com';
+  const { language, t } = useLanguage();
+  const z = (english: string, chinese: string) => (language === 'zh-CN' ? chinese : english);
+  const defaultPlaceholder = language === 'zh-CN' ? '例如：duck.com' : 'e.g. duck.com';
   const [userInput, setUserInput] = useState('');
   const [errorMsg, setErrMsg] = useState('');
-  const [placeholder] = useState(defaultPlaceholder);
+  const placeholder = defaultPlaceholder;
   const [inputDisabled] = useState(false);
   const navigate = useNavigate();
 
@@ -152,9 +164,9 @@ const Home = (): JSX.Element => {
     const addressType = determineAddressType(address);
 
     if (addressType === 'empt') {
-      setErrMsg('Field must not be empty');
+      setErrMsg(t('emptyInput'));
     } else if (addressType === 'err') {
-      setErrMsg('Must be a valid URL, IPv4 or IPv6 Address');
+      setErrMsg(t('invalidInput'));
     } else {
       const resultRouteParams: NavigateOptions = { state: { address, addressType } };
       navigate(`/check/${address}`, resultRouteParams);
@@ -183,17 +195,20 @@ const Home = (): JSX.Element => {
   return (
     <HomeContainer>
       <FancyBackground />
+      <LanguagePosition>
+        <LanguageSwitcher />
+      </LanguagePosition>
       <UserInputMain onSubmit={formSubmitEvent}>
         <a href="/">
           <Heading as="h1" size="xLarge" align="center" color={colors.primary}>
-            <img width="64" src="/web-check.png" alt="Web Check Icon" />
+            <img width="64" src="/web-check.png" alt={z('Web Check icon', 'Web Check 图标')} />
             Web Check
           </Heading>
         </a>
         <Input
           id="user-input"
           value={userInput}
-          label="Enter a URL"
+          label={t('enterUrl')}
           size="large"
           orientation="vertical"
           name="url"
@@ -205,37 +220,40 @@ const Home = (): JSX.Element => {
         {/* <FindIpButton onClick={findIpAddress}>Or, find my IP</FindIpButton> */}
         {errorMsg && <ErrorMessage>{errorMsg}</ErrorMessage>}
         <Button type="submit" styles="width: calc(100% - 1rem);" size="large" onClick={submit}>
-          Analyze!
+          {t('analyze')}
         </Button>
       </UserInputMain>
       <SponsorCard>
         <Heading as="h2" size="small" color={colors.primary}>
-          Enjoying Web Check?
+          {t('enjoying')}
         </Heading>
         <p>
-          It's free, open source, and funded by the community. If it's been useful, you can keep it
-          going (and ad-free) by{' '}
+          {t('sponsorBefore')}{' '}
           <a target="_blank" rel="noreferrer" href="https://github.com/sponsors/Lissy93">
-            sponsoring me on GitHub
+            {t('sponsorLink')}
           </a>
-          . Every bit genuinely helps, thank you
+          {language === 'zh-CN' ? '，' : '. '}
+          {t('sponsorAfter')}
         </p>
       </SponsorCard>
       <SiteFeaturesWrapper>
         <div className="features">
           <Heading as="h2" size="small" color={colors.primary}>
-            Supported Checks
+            {t('supportedChecks')}
           </Heading>
           <ul>
             {docs.map((doc, index) => (
               <li key={index}>
-                <Link to={`/check/about#${makeAnchor(doc.title)}`} title={doc.title}>
-                  {doc.title}
+                <Link
+                  to={`/check/about#${makeAnchor(doc.title)}`}
+                  title={localizeDoc(doc, language).title}
+                >
+                  {localizeDoc(doc, language).title}
                 </Link>
               </li>
             ))}
             <li>
-              <Link to="/check/about">+ more!</Link>
+              <Link to="/check/about">{z('+ more!', '+ 更多')}</Link>
             </li>
           </ul>
         </div>
@@ -244,23 +262,32 @@ const Home = (): JSX.Element => {
             target="_blank"
             rel="noreferrer"
             href="https://github.com/lissy93/web-check"
-            title="Check out the source code and documentation on GitHub, and get support or contribute"
+            title={z(
+              'Check out the source code and documentation on GitHub, and get support or contribute',
+              '在 GitHub 查看源代码和文档、获取支持或参与贡献',
+            )}
           >
-            <Button>View on GitHub</Button>
+            <Button>{t('viewGithub')}</Button>
           </a>
           <a
             target="_blank"
             rel="noreferrer"
             href="https://app.netlify.com/start/deploy?repository=https://github.com/lissy93/web-check"
-            title="Deploy your own private or public instance of Web-Check to Netlify"
+            title={z(
+              'Deploy your own private or public instance of Web-Check to Netlify',
+              '在 Netlify 部署自己的私有或公开 Web Check 实例',
+            )}
           >
-            <Button>Deploy your own</Button>
+            <Button>{t('deployOwn')}</Button>
           </a>
           <Link
             to="/check/about#api-documentation"
-            title="View the API documentation, to use Web-Check programmatically"
+            title={z(
+              'View the API documentation, to use Web-Check programmatically',
+              '查看 API 文档，以编程方式使用 Web Check',
+            )}
           >
-            <Button>API Docs</Button>
+            <Button>{t('apiDocs')}</Button>
           </Link>
         </div>
       </SiteFeaturesWrapper>

--- a/src/client/views/NotFound.tsx
+++ b/src/client/views/NotFound.tsx
@@ -6,6 +6,7 @@ import Footer from 'client/components/misc/Footer';
 import Nav from 'client/components/Form/Nav';
 import Button from 'client/components/Form/Button';
 import { StyledCard } from 'client/components/Form/Card';
+import { useLanguage } from 'client/i18n';
 
 const AboutContainer = styled.div`
   width: 95vw;
@@ -46,6 +47,7 @@ const NotFoundInner = styled(StyledCard)`
 `;
 
 const NotFound = (): JSX.Element => {
+  const { t } = useLanguage();
   return (
     <>
       <AboutContainer>
@@ -56,15 +58,15 @@ const NotFound = (): JSX.Element => {
           </Heading>
           <span className="im-drink">🥴</span>
           <Heading as="h3" size="large" color={colors.primary}>
-            Not Found
+            {t('notFound')}
           </Heading>
           <HeaderLinkContainer>
             <a href="/">
-              <Button>Back to Homepage</Button>
+              <Button>{t('backHome')}</Button>
             </a>
           </HeaderLinkContainer>
           <a target="_blank" rel="noreferrer" href="https://github.com/lissy93/web-check">
-            Report Issue
+            {t('reportIssue')}
           </a>
         </NotFoundInner>
       </AboutContainer>

--- a/src/client/views/Results.tsx
+++ b/src/client/views/Results.tsx
@@ -28,6 +28,7 @@ import keys from 'client/utils/get-keys';
 import useJobs from 'client/hooks/useJobs';
 import { jobs, allCards, allCardIds } from 'client/jobs/registry';
 import { runAnalysis } from 'client/analysis/registry';
+import { localizeCardTitle, useLanguage } from 'client/i18n';
 
 const ResultsOuter = styled.div`
   display: flex;
@@ -65,16 +66,22 @@ const makeSiteName = (address: string): string => {
   }
 };
 
-const makeActionButtons = (title: string, refresh: () => void, showInfo: () => void): ReactNode => (
+const makeActionButtons = (
+  infoLabel: string,
+  refreshLabel: string,
+  refresh: () => void,
+  showInfo: () => void,
+): ReactNode => (
   <ActionButtons
     actions={[
-      { label: `Info about ${title}`, onClick: showInfo, icon: 'ⓘ' },
-      { label: `Re-fetch ${title} data`, onClick: refresh, icon: '↻' },
+      { label: infoLabel, onClick: showInfo, icon: 'ⓘ' },
+      { label: refreshLabel, onClick: refresh, icon: '↻' },
     ]}
   />
 );
 
 const Results = (props: { address?: string }): JSX.Element => {
+  const { language, t } = useLanguage();
   const { urlToScan } = useParams();
   const address = props.address || urlToScan || '';
   const addressType: AddressType = useMemo(() => determineAddressType(address), [address]);
@@ -115,7 +122,7 @@ const Results = (props: { address?: string }): JSX.Element => {
   }, [jobsState]);
 
   const showInfo = (id: string) => {
-    setModalContent(DocContent(id));
+    setModalContent(<DocContent id={id} />);
     setModalOpen(true);
   };
 
@@ -202,29 +209,33 @@ const Results = (props: { address?: string }): JSX.Element => {
       <AdvisoryPanel findings={findings} onJumpTo={jumpToCard} />
       <ResultsContent>
         <ResultsMasonryGrid minColWidth={336}>
-          {cardsToShow.map(({ card, data }) => (
-            <div id={`card-${card.id}`} key={`eb-${card.id}`}>
-              <ErrorBoundary title={card.title}>
-                <card.Component
-                  key={card.id}
-                  data={data}
-                  title={card.title}
-                  actionButtons={makeActionButtons(
-                    card.title,
-                    () => retry(card.id),
-                    () => showInfo(card.id),
-                  )}
-                />
-              </ErrorBoundary>
-            </div>
-          ))}
+          {cardsToShow.map(({ card, data }) => {
+            const title = localizeCardTitle(card.id, card.title, language);
+            return (
+              <div id={`card-${card.id}`} key={`eb-${card.id}`}>
+                <ErrorBoundary title={title}>
+                  <card.Component
+                    key={card.id}
+                    data={data}
+                    title={title}
+                    actionButtons={makeActionButtons(
+                      t('infoAbout', { title }),
+                      t('refetch', { title }),
+                      () => retry(card.id),
+                      () => showInfo(card.id),
+                    )}
+                  />
+                </ErrorBoundary>
+              </div>
+            );
+          })}
         </ResultsMasonryGrid>
       </ResultsContent>
       {!errorKind && (
         <ViewRaw
           everything={renderable.map((r) => ({
             id: r.card.id,
-            title: r.card.title,
+            title: localizeCardTitle(r.card.id, r.card.title, language),
             result: r.data,
           }))}
         />

--- a/src/components/homepage/AboutSection.astro
+++ b/src/components/homepage/AboutSection.astro
@@ -4,55 +4,58 @@ import Features from '@components/homepage/Features.astro';
 import SponsorSegment from '@components/homepage/SponsorSegment.astro';
 
 const supportedChecks = [
-  'Archive History',
-  'Block List Check',
-  'Carbon Footprint',
-  'Cookies',
-  'DNS Server',
-  'DNS Records',
-  'DNSSEC',
-  'Site Features',
-  'Firewall Types',
-  'Get IP Address',
-  'Headers',
-  'HSTS',
-  'HTTP Security',
-  'Linked Pages',
-  'Mail Config',
-  'Open Ports',
-  'Quality Check',
-  'Global Rank',
-  'Redirects',
-  'Robots.txt',
-  'Screenshot',
-  'Security.txt',
-  'Sitemap',
-  'Social Tags',
-  'SSL Certificate',
-  'Uptime Status',
-  'Tech Stack',
-  'Known Threats',
-  'TLS Version',
-  'Trace Route',
-  'TXT Records',
-  'Whois Lookup',
+  { en: 'Archive History', zh: '历史归档' },
+  { en: 'Block List Check', zh: '拦截名单检测' },
+  { en: 'Carbon Footprint', zh: '碳足迹' },
+  { en: 'Cookies', zh: 'Cookie' },
+  { en: 'DNS Server', zh: 'DNS 服务器' },
+  { en: 'DNS Records', zh: 'DNS 记录' },
+  { en: 'DNSSEC', zh: 'DNSSEC' },
+  { en: 'Site Features', zh: '网站特征' },
+  { en: 'Firewall Types', zh: '防火墙类型' },
+  { en: 'Get IP Address', zh: '获取 IP 地址' },
+  { en: 'Headers', zh: '响应头' },
+  { en: 'HSTS', zh: 'HSTS' },
+  { en: 'HTTP Security', zh: 'HTTP 安全' },
+  { en: 'Linked Pages', zh: '页面链接' },
+  { en: 'Mail Config', zh: '邮件配置' },
+  { en: 'Open Ports', zh: '开放端口' },
+  { en: 'Quality Check', zh: '质量检查' },
+  { en: 'Global Rank', zh: '全球排名' },
+  { en: 'Redirects', zh: '重定向' },
+  { en: 'Robots.txt', zh: 'Robots.txt' },
+  { en: 'Screenshot', zh: '网页截图' },
+  { en: 'Security.txt', zh: 'Security.txt' },
+  { en: 'Sitemap', zh: '站点地图' },
+  { en: 'Social Tags', zh: '社交标签' },
+  { en: 'SSL Certificate', zh: 'SSL 证书' },
+  { en: 'Uptime Status', zh: '在线状态' },
+  { en: 'Tech Stack', zh: '技术栈' },
+  { en: 'Known Threats', zh: '已知威胁' },
+  { en: 'TLS Version', zh: 'TLS 版本' },
+  { en: 'Trace Route', zh: '路由追踪' },
+  { en: 'TXT Records', zh: 'TXT 记录' },
+  { en: 'Whois Lookup', zh: 'WHOIS 查询' },
 ];
 
 const links = [
   {
     title: 'View on GitHub',
+    titleZh: '在 GitHub 查看',
     url: 'https://github.com/lissy93/web-check',
     icon: 'github',
     isCta: true,
   },
   {
     title: 'Deploy your Own',
+    titleZh: '部署自己的实例',
     url: '/self-hosted-setup',
     icon: 'rocket',
     isCta: false,
   },
   {
     title: 'Use the API',
+    titleZh: '使用 API',
     url: '/web-check-api',
     icon: 'code',
     isCta: false,
@@ -62,10 +65,15 @@ const links = [
 
 <div class="about-section">
   <div class="features-wrap">
-    <h4>Ready to get started?</h4>
+    <h4>
+      <span class="i18n-en">Ready to get started?</span><span class="i18n-zh">准备开始了吗？</span>
+    </h4>
     <p class="what">
-      With over <span>30 supported checks</span>
-      you can view and analyse key website information in an instant
+      <span class="i18n-en"
+        >With over <em>30 supported checks</em> you can view and analyse key website information in an
+        instant</span
+      >
+      <span class="i18n-zh">提供超过 <em>30 项检查</em>，快速查看并分析网站关键信息</span>
     </p>
   </div>
   <hr />
@@ -98,7 +106,7 @@ const links = [
     text-align: center;
     font-size: 1.2rem;
     line-height: 1.5;
-    span {
+    em {
       color: var(--primary);
       font-style: italic;
     }

--- a/src/components/homepage/AnimatedButton.astro
+++ b/src/components/homepage/AnimatedButton.astro
@@ -1,9 +1,10 @@
 ---
-const buttonText = 'Analyze URL';
 const buttonType = 'submit';
 ---
 
-<button class="button" type={buttonType}>{buttonText}</button>
+<button class="button" type={buttonType}>
+  <span class="i18n-en">Analyze URL</span><span class="i18n-zh">分析网址</span>
+</button>
 
 <style lang="scss">
   @property --angle {

--- a/src/components/homepage/AnimatedInput.astro
+++ b/src/components/homepage/AnimatedInput.astro
@@ -24,7 +24,9 @@ const placeholders = [
     placeholder="E.g. duck.com"
   />
   <div class="placeholder-container">
-    <span class="starter" aria-hidden="true">E.g.</span>
+    <span class="starter" aria-hidden="true">
+      <span class="i18n-en">E.g.</span><span class="i18n-zh">例如</span>
+    </span>
     {
       placeholders.map((placeholder, index) => (
         <span class={`placeholder ${index === 0 ? 'active' : ''}`} aria-hidden="true">

--- a/src/components/homepage/ButtonGroup.astro
+++ b/src/components/homepage/ButtonGroup.astro
@@ -4,6 +4,7 @@ import Icon from '@components/molecules/Icon.svelte';
 interface Props {
   links: {
     title: string;
+    titleZh: string;
     url: string;
     icon: string;
     isCta: boolean;
@@ -18,7 +19,10 @@ const { links } = Astro.props;
     links.map((link: Props['links'][number]) => (
       <a href={link.url} class={link.isCta ? 'cta' : ''}>
         <Icon name={link.icon} size={2} />
-        {link.title}
+        <>
+          <span class="i18n-en">{link.title}</span>
+          <span class="i18n-zh">{link.titleZh}</span>
+        </>
       </a>
     ))
   }

--- a/src/components/homepage/Features.astro
+++ b/src/components/homepage/Features.astro
@@ -2,7 +2,7 @@
 import Icon from '@components/molecules/Icon.svelte';
 
 interface Props {
-  supportedChecks: string[];
+  supportedChecks: { en: string; zh: string }[];
 }
 
 const { supportedChecks } = Astro.props;
@@ -10,14 +10,20 @@ const { supportedChecks } = Astro.props;
 
 <ul class="features">
   {
-    supportedChecks.map((check: string) => (
+    supportedChecks.map((check: Props['supportedChecks'][number]) => (
       <li>
         <Icon name="check" />
-        {check}
+        <>
+          <span class="i18n-en">{check.en}</span>
+          <span class="i18n-zh">{check.zh}</span>
+        </>
       </li>
     ))
   }
-  <li><Icon name="plus" /><a href="/about#features">More</a></li>
+  <li>
+    <Icon name="plus" />
+    <a href="/about#features"><span class="i18n-en">More</span><span class="i18n-zh">更多</span></a>
+  </li>
 </ul>
 
 <style lang="scss">

--- a/src/components/homepage/HeroForm.astro
+++ b/src/components/homepage/HeroForm.astro
@@ -2,23 +2,35 @@
 import AnimatedButton from './AnimatedButton.astro';
 import AnimatedInput from './AnimatedInput.astro';
 import Screenshots from './Screenshots.astro';
+import LanguageSwitcher from '@components/molecules/LanguageSwitcher.astro';
 ---
 
 <div class="hero">
   <div class="left">
-    <h1>
-      <img src="/favicon.svg" alt="Check Web" width="64" />
-      <span class="web">Web</span>
-      <span class="check">Check</span>
-    </h1>
+    <div class="hero-topbar">
+      <h1>
+        <img src="/favicon.svg" alt="Check Web" width="64" />
+        <span class="web">Web</span>
+        <span class="check">Check</span>
+      </h1>
+      <LanguageSwitcher />
+    </div>
     <div class="homepage-action-content">
-      <h2>We give you X-Ray<br />Vision for your Website</h2>
+      <h2>
+        <span class="i18n-en">We give you X-Ray<br />Vision for your Website</span>
+        <span class="i18n-zh">透视网站配置<br />看清潜在风险</span>
+      </h2>
       <h3>
-        In just 20 seconds, you can see
-        <span>what attackers already know</span>
+        <span class="i18n-en"
+          >In just 20 seconds, you can see <em>what attackers already know</em></span
+        >
+        <span class="i18n-zh">只需 20 秒，即可看到 <em>攻击者已经掌握的信息</em></span>
       </h3>
       <form name="live-start" autocomplete="off" action="/check" class="live-start" id="live-start">
-        <label for="url">Enter a URL to start 👇</label>
+        <label for="url">
+          <span class="i18n-en">Enter a URL to start</span>
+          <span class="i18n-zh">输入网址开始检查</span> 👇
+        </label>
         <AnimatedInput />
         <AnimatedButton />
       </form>
@@ -63,6 +75,13 @@ import Screenshots from './Screenshots.astro';
     @include mobile-down {
       gap: 4rem;
     }
+    .hero-topbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      z-index: 5;
+    }
     h1 {
       margin: 0;
       fontis-size: 3em;
@@ -99,7 +118,7 @@ import Screenshots from './Screenshots.astro';
       h3 {
         font-weight: normal;
         font-size: 1.3rem;
-        span {
+        em {
           color: var(--primary);
           font-style: italic;
         }

--- a/src/components/homepage/SponsorSegment.astro
+++ b/src/components/homepage/SponsorSegment.astro
@@ -13,10 +13,17 @@ const ctaImageSrc = 'https://i.ibb.co/5jJ4bzZ/terminal-trove-cta.png';
 
 <div class="sponsored-but-dont-block">
   <div>
-    <h5>Sponsored by <a href={sponsorLink}>{sponsorName}</a></h5>
+    <h5>
+      <span class="i18n-en">Sponsored by</span><span class="i18n-zh">赞助伙伴</span>
+      <a href={sponsorLink}>{sponsorName}</a>
+    </h5>
     <p>
-      {sponsorTagline}<br />
-      {ctaPreText}
+      <span class="i18n-en">{sponsorTagline}</span><span class="i18n-zh"
+        >终端工具的一站式发现平台。</span
+      ><br />
+      <span class="i18n-en">{ctaPreText}</span><span class="i18n-zh"
+        >通过邮件订阅获取最新 CLI/TUI 工具：</span
+      >
       <a href={ctaLinkHref}>{ctaLinkText}</a>
     </p>
   </div>

--- a/src/components/homepage/TempDisabled.astro
+++ b/src/components/homepage/TempDisabled.astro
@@ -1,7 +1,12 @@
 <div class="banner">
   <p>
-    ⚠️ Web Check is temporarily disabled due to excess demand and associated costs. We apologize for
-    any inconvenience and are working on a solution.
+    <span class="i18n-en"
+      >⚠️ Web Check is temporarily disabled due to excess demand and associated costs. We apologize
+      for any inconvenience and are working on a solution.</span
+    >
+    <span class="i18n-zh"
+      >⚠️ 由于访问量和运行成本过高，Web Check 已暂时停用。给你带来不便，我们深表歉意，并正在处理。</span
+    >
   </p>
 </div>
 

--- a/src/components/molecules/LanguageSwitcher.astro
+++ b/src/components/molecules/LanguageSwitcher.astro
@@ -1,0 +1,72 @@
+<div class="language-switcher" role="group" aria-label="Language / 语言">
+  <button type="button" data-language="en" title="English">EN</button>
+  <button type="button" data-language="zh-CN" title="中文">中文</button>
+</div>
+
+<script>
+  const storageKey = 'web-check-language';
+
+  const initializeLanguageSwitcher = () => {
+    document.querySelectorAll<HTMLElement>('.language-switcher').forEach((switcher) => {
+      const buttons = switcher.querySelectorAll<HTMLButtonElement>('button[data-language]');
+      const update = () => {
+        const current = document.documentElement.lang.startsWith('zh') ? 'zh-CN' : 'en';
+        buttons.forEach((button) => {
+          button.setAttribute('aria-pressed', String(button.dataset.language === current));
+        });
+      };
+
+      buttons.forEach((button) => {
+        if (button.dataset.bound === 'true') return;
+        button.dataset.bound = 'true';
+        button.addEventListener('click', () => {
+          const language = button.dataset.language === 'zh-CN' ? 'zh-CN' : 'en';
+          document.documentElement.lang = language;
+          window.localStorage.setItem(storageKey, language);
+          window.dispatchEvent(new CustomEvent('web-check-language-change', { detail: language }));
+          update();
+        });
+      });
+      update();
+      window.addEventListener('web-check-language-change', update);
+    });
+  };
+
+  document.addEventListener('astro:page-load', initializeLanguageSwitcher);
+  initializeLanguageSwitcher();
+</script>
+
+<style>
+  .language-switcher {
+    display: inline-grid;
+    grid-template-columns: repeat(2, minmax(3rem, auto));
+    height: 2rem;
+    padding: 2px;
+    border: 1px solid var(--primary-transparent);
+    border-radius: 4px;
+    background: var(--background);
+    flex: 0 0 auto;
+  }
+  button {
+    min-width: 0;
+    border: 0;
+    border-radius: 2px;
+    padding: 0 0.55rem;
+    background: transparent;
+    color: var(--text-color-secondary);
+    font: inherit;
+    font-size: 0.8rem;
+    line-height: 1;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  button[aria-pressed='true'] {
+    background: var(--primary);
+    color: var(--background);
+    font-weight: 700;
+  }
+  button:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+</style>

--- a/src/components/scafold/Footer.astro
+++ b/src/components/scafold/Footer.astro
@@ -15,11 +15,12 @@ const currentYear = new Date().getFullYear();
 
 <footer>
   <p>
-    View source at <a href={github}>{repo}</a>
+    <span class="i18n-en">View source at</span><span class="i18n-zh">源代码：</span>
+    <a href={github}>{repo}</a>
   </p>
   <p>
     <a href={aboutLink}>{projectName}</a>
-    is licensed under
+    <span class="i18n-en">is licensed under</span><span class="i18n-zh">采用</span>
     <a href={licenseLink}>{licenseText}</a>
     - © <a href={authorLink}>{authorName}</a>
     {currentYear}

--- a/src/components/scafold/Nav.astro
+++ b/src/components/scafold/Nav.astro
@@ -1,5 +1,5 @@
 ---
-
+import LanguageSwitcher from '@components/molecules/LanguageSwitcher.astro';
 ---
 
 <nav class="navbar">
@@ -13,9 +13,14 @@
     </a>
   </div>
   <div class="nav-right">
-    <a href="/check" class="nav-link">Check</a>
+    <a href="/check" class="nav-link">
+      <span class="i18n-en">Check</span><span class="i18n-zh">检查</span>
+    </a>
     <a href="/web-check-api" class="nav-link">API</a>
-    <a href="/account" class="nav-link">Login</a>
+    <a href="/account" class="nav-link">
+      <span class="i18n-en">Login</span><span class="i18n-zh">登录</span>
+    </a>
+    <LanguageSwitcher />
   </div>
 </nav>
 
@@ -69,11 +74,13 @@
 
     .nav-right {
       display: flex;
+      align-items: center;
+      gap: 0.5rem;
 
       .nav-link {
         text-decoration: none;
         color: var(--text-color);
-        margin-left: 1rem;
+        margin-left: 0.5rem;
         padding: 0.5rem;
         transition: background-color 0.3s;
         position: relative;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -25,6 +25,18 @@ const { preloadBodyFont = true } = Astro.props;
 <!doctype html>
 <html lang="en" data-theme="dark">
   <head>
+    <script is:inline>
+      (() => {
+        const stored = window.localStorage.getItem('web-check-language');
+        const language =
+          stored === 'en' || stored === 'zh-CN'
+            ? stored
+            : navigator.language.toLowerCase().startsWith('zh')
+              ? 'zh-CN'
+              : 'en';
+        document.documentElement.lang = language;
+      })();
+    </script>
     <ClientRouter />
     <MetaTags {...Astro.props} />
     <slot name="head" />

--- a/src/pages/account/index.astro
+++ b/src/pages/account/index.astro
@@ -17,10 +17,18 @@ import Footer from '@components/scafold/Footer.astro';
       </p> -->
 
       <div class="under-development">
-        <h4>Account management is currently under development.</h4>
+        <h4>
+          <span class="i18n-en">Account management is currently under development.</span>
+          <span class="i18n-zh">账户管理功能正在开发中。</span>
+        </h4>
         <p>
-          Once complete, you will be able to login to your account to manage API access, save
-          reports, enable website change notificiations and more!
+          <span class="i18n-en"
+            >Once complete, you will be able to login to your account to manage API access, save
+            reports, enable website change notifications and more!</span
+          >
+          <span class="i18n-zh"
+            >功能完成后，你可以登录账户管理 API 访问、保存报告、启用网站变更通知等功能。</span
+          >
         </p>
       </div>
     </main>

--- a/src/pages/self-hosted-setup.astro
+++ b/src/pages/self-hosted-setup.astro
@@ -7,17 +7,22 @@ import Icon from '@components/molecules/Icon.svelte';
 const cardData = [
   {
     title: 'Deploy with Docker',
+    titleZh: '使用 Docker 部署',
     description:
       "Just one command, and you'll have your own Web Check instance running on your server in minutes.",
+    descriptionZh: '只需一条命令，几分钟内即可在服务器上运行自己的 Web Check 实例。',
     command: 'docker run -p 3000:3000 lissy93/web-check',
   },
   {
     title: '1-Click Deploy',
+    titleZh: '一键部署',
     description:
       "Don't have a server? Not a problem! Deploy Web Check with one click on Vercel, Netlify, or Render.",
+    descriptionZh: '没有服务器也没关系，可以一键部署到 Vercel、Netlify 或 Render。',
     buttons: [
       {
         name: 'Vercel',
+        nameZh: 'Vercel',
         image: '/assets/images/vercel.svg',
         link:
           'https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.' +
@@ -28,6 +33,7 @@ const cardData = [
       },
       {
         name: 'Netlify',
+        nameZh: 'Netlify',
         image: '/assets/images/netlify.svg',
         link:
           'https://app.netlify.com/start/deploy?repository=' +
@@ -35,6 +41,7 @@ const cardData = [
       },
       {
         name: 'Render',
+        nameZh: 'Render',
         image: '/assets/images/render.svg',
         link: 'https://render.com/deploy?repo=https://github.com/Lissy93/web-check',
       },
@@ -42,10 +49,13 @@ const cardData = [
   },
   {
     title: 'Build from Source',
+    titleZh: '从源代码构建',
     description: 'Want to customize Web Check? Clone the repository and deploy it on your server.',
+    descriptionZh: '需要定制 Web Check？克隆代码仓库并部署到自己的服务器。',
     buttons: [
       {
         name: 'GitHub',
+        nameZh: 'GitHub',
         image: '/assets/images/github.svg',
         link: '',
       },
@@ -61,22 +71,43 @@ const cardData = [
   <div class="web-check-page">
     <NavBar />
     <main>
-      <h1>Self-Hosted Setup</h1>
-      <p>Get your own free instance of Web Check, running locally or on your server.</p>
+      <h1><span class="i18n-en">Self-Hosted Setup</span><span class="i18n-zh">自托管部署</span></h1>
+      <p>
+        <span class="i18n-en"
+          >Get your own free instance of Web Check, running locally or on your server.</span
+        ><span class="i18n-zh">在本地或服务器上运行免费的 Web Check 实例。</span>
+      </p>
 
       <div class="option-cards">
         {
           cardData.map((card, cardIndex) => (
             <div class="card">
-              <span class="option">Option #{cardIndex + 1}</span>
-              <h3>{card.title}</h3>
-              <p>{card.description}</p>
+              <span class="option">
+                <>
+                  <span class="i18n-en">Option</span>
+                  <span class="i18n-zh">方式</span>
+                </>{' '}
+                #{cardIndex + 1}
+              </span>
+              <h3>
+                <>
+                  <span class="i18n-en">{card.title}</span>
+                  <span class="i18n-zh">{card.titleZh}</span>
+                </>
+              </h3>
+              <p>
+                <>
+                  <span class="i18n-en">{card.description}</span>
+                  <span class="i18n-zh">{card.descriptionZh}</span>
+                </>
+              </p>
               {card.buttons && (
                 <div class="buttons">
                   {card.buttons.map((button) => (
                     <a href={button.link}>
                       <img src={button.image} />
-                      {button.name}
+                      <span class="i18n-en">{button.name}</span>
+                      <span class="i18n-zh">{button.nameZh}</span>
                     </a>
                   ))}
                 </div>

--- a/src/pages/web-check-api/index.astro
+++ b/src/pages/web-check-api/index.astro
@@ -10,35 +10,54 @@ import Footer from '@components/scafold/Footer.astro';
     <main>
       <h1>Web Check API</h1>
       <p class="intro">
-        The Web Check API gives you programatic access to over 30 categories of web metrics.<br />
-        Integrate into your own workflows and applications, to monitor any website's performance, SEO,
-        security, and more.
+        <span class="i18n-en"
+          >The Web Check API gives you programmatic access to over 30 categories of web metrics.<br
+          />Integrate it into your workflows and applications to monitor website performance, SEO,
+          security, and more.</span
+        >
+        <span class="i18n-zh"
+          >Web Check API 提供 30 多类网站指标的程序化访问能力。<br
+          />你可以将它集成到工作流和应用中，监控网站性能、SEO、安全等信息。</span
+        >
       </p>
 
       <div class="option-cards">
         <div class="card">
-          <h3>API Documentation</h3>
-          <p>View listing of all available endpoints, their usage, output and examples.</p>
+          <h3>
+            <span class="i18n-en">API Documentation</span><span class="i18n-zh">API 文档</span>
+          </h3>
+          <p>
+            <span class="i18n-en">View all available endpoints, usage, output and examples.</span
+            ><span class="i18n-zh">查看全部可用端点、用法、输出和示例。</span>
+          </p>
           <div class="buttons">
             <a href="/web-check-api/spec">
               <img src="/assets/images/swagger.svg" />
-              OpenAPI Spec
+              <span class="i18n-en">OpenAPI Spec</span><span class="i18n-zh">OpenAPI 规范</span>
             </a>
           </div>
         </div>
         <div class="card">
-          <h3>API Key</h3>
-          <p>Get your API key, and start using the API.</p>
+          <h3><span class="i18n-en">API Key</span><span class="i18n-zh">API 密钥</span></h3>
+          <p>
+            <span class="i18n-en">Get your API key and start using the API.</span><span
+              class="i18n-zh">获取 API 密钥并开始使用接口。</span
+            >
+          </p>
           <div class="buttons">
             <a href="/account">
               <img src="/assets/images/webauthn.svg" />
-              Sign Up
+              <span class="i18n-en">Sign Up</span><span class="i18n-zh">注册</span>
             </a>
           </div>
         </div>
         <div class="card">
-          <h3>API Source</h3>
-          <p>View, edit, download or deploy the API from source.</p>
+          <h3><span class="i18n-en">API Source</span><span class="i18n-zh">API 源代码</span></h3>
+          <p>
+            <span class="i18n-en">View, edit, download or deploy the API from source.</span><span
+              class="i18n-zh">查看、编辑、下载或从源代码部署 API。</span
+            >
+          </p>
           <div class="buttons">
             <a href="https://github.com/xray-web/web-check-api" target="_blank" rel="noreferrer">
               <img src="/assets/images/github.svg" />

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -24,6 +24,19 @@ html {
   scroll-behavior: smooth;
 }
 
+.i18n-zh {
+  display: none;
+}
+
+html[lang^='zh'] {
+  .i18n-en {
+    display: none;
+  }
+  .i18n-zh {
+    display: contents;
+  }
+}
+
 body {
   font-family: var(--font-sans);
   line-height: 1;


### PR DESCRIPTION
## Summary

This PR adds Simplified Chinese (`zh-CN`) localization and an English/Chinese language switcher across Web Check.

## Changes

- Added a shared localization system for React views and result components
- Added language switchers to both React and Astro pages
- Added Simplified Chinese translations for:
  - Home, results, About, and error pages
  - All 39 check descriptions and result fields
  - Loading, progress, advisory, empty, and error states
  - Account, API overview, and self-hosted setup pages
  - Navigation, footer, buttons, tooltips, and accessibility labels
- Detects the browser language on first visit
- Persists the selected language in `localStorage`
- Updates the document language through the `lang` attribute
- Allows switching languages without restarting an active scan
- Keeps technical values such as CVEs, protocols, domain names, and product names untranslated

## Additional Fix

While testing the production server locally on Windows, I found that absolute filesystem paths were passed directly to ESM `import()` calls. This PR converts them to proper file URLs using `fileURLToPath` and `pathToFileURL`, allowing the local production server and API routes to start correctly on Windows.

## Testing

- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn build`
- [x] Prettier check for all modified files
- [x] Local production health check
- [x] English and Chinese switching
- [x] Language persistence after reload and navigation
- [x] Desktop layout at 1440×900
- [x] Mobile layout at 390×844
- [x] Verified `/check`, `/check/about`, `/account`, `/web-check-api`, and `/self-hosted-setup`
- [x] No browser console errors or horizontal overflow

No new runtime dependencies were added.